### PR TITLE
chore: update Astro to v6 and upgrade dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: "npm"
@@ -36,13 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-      - name: Install dependencies
-        run: npm ci
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run prek hooks
-        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d
+        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d # v2.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run Astro type check
+        run: npm run check
+      - name: Run markdown lint
+        run: npm run lint:md
+
+  prek:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run prek hooks
+        uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,11 +26,7 @@ jobs:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
       - name: Install, build, and upload your site
-        uses: withastro/action@v3
-        # with:
-        # path: . # The root location of your Astro project inside the repository. (optional)
-        # node-version: 20 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
-        # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        uses: withastro/action@v6
 
   deploy:
     needs: build
@@ -41,4 +37,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install, build, and upload your site
-        uses: withastro/action@v6
+        uses: withastro/action@b7d53628f8b666036b0238aadb0b984a2a489f26 # v6
 
   deploy:
     needs: build
@@ -37,4 +37,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+    "default": true,
+    "MD013": {
+        "line_length": 120,
+        "code_blocks": false
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,58 @@
                 "astro": "^6.4.2"
             },
             "devDependencies": {
+                "@astrojs/check": "^0.9.9",
+                "markdownlint-cli": "^0.48.0",
                 "typescript": "^5.8.3"
+            }
+        },
+        "node_modules/@astrojs/check": {
+            "version": "0.9.9",
+            "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
+            "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@astrojs/language-server": "^2.16.7",
+                "chokidar": "^4.0.3",
+                "kleur": "^4.1.5",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "astro-check": "bin/astro-check.js"
+            },
+            "peerDependencies": {
+                "typescript": "^5.0.0 || ^6.0.0"
+            }
+        },
+        "node_modules/@astrojs/check/node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@astrojs/check/node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@astrojs/compiler": {
@@ -35,6 +86,55 @@
                 "smol-toml": "^1.6.0",
                 "unified": "^11.0.5"
             }
+        },
+        "node_modules/@astrojs/language-server": {
+            "version": "2.16.10",
+            "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.10.tgz",
+            "integrity": "sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@astrojs/compiler": "^2.13.1",
+                "@astrojs/yaml2ts": "^0.2.4",
+                "@jridgewell/sourcemap-codec": "^1.5.5",
+                "@volar/kit": "~2.4.28",
+                "@volar/language-core": "~2.4.28",
+                "@volar/language-server": "~2.4.28",
+                "@volar/language-service": "~2.4.28",
+                "muggle-string": "^0.4.1",
+                "tinyglobby": "^0.2.16",
+                "volar-service-css": "0.0.70",
+                "volar-service-emmet": "0.0.70",
+                "volar-service-html": "0.0.70",
+                "volar-service-prettier": "0.0.70",
+                "volar-service-typescript": "0.0.70",
+                "volar-service-typescript-twoslash-queries": "0.0.70",
+                "volar-service-yaml": "0.0.70",
+                "vscode-html-languageservice": "^5.6.2",
+                "vscode-uri": "^3.1.0"
+            },
+            "bin": {
+                "astro-ls": "bin/nodeServer.js"
+            },
+            "peerDependencies": {
+                "prettier": "^3.0.0",
+                "prettier-plugin-astro": ">=0.11.0"
+            },
+            "peerDependenciesMeta": {
+                "prettier": {
+                    "optional": true
+                },
+                "prettier-plugin-astro": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@astrojs/language-server/node_modules/@astrojs/compiler": {
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+            "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@astrojs/markdown-remark": {
             "version": "7.2.0",
@@ -87,6 +187,16 @@
             },
             "engines": {
                 "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+            }
+        },
+        "node_modules/@astrojs/yaml2ts": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+            "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yaml": "^2.8.3"
             }
         },
         "node_modules/@babel/helper-string-parser": {
@@ -174,6 +284,68 @@
             "engines": {
                 "node": ">= 20.12.0"
             }
+        },
+        "node_modules/@emmetio/abbreviation": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+            "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@emmetio/scanner": "^1.0.4"
+            }
+        },
+        "node_modules/@emmetio/css-abbreviation": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+            "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@emmetio/scanner": "^1.0.4"
+            }
+        },
+        "node_modules/@emmetio/css-parser": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+            "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@emmetio/stream-reader": "^2.2.0",
+                "@emmetio/stream-reader-utils": "^0.1.0"
+            }
+        },
+        "node_modules/@emmetio/html-matcher": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+            "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "@emmetio/scanner": "^1.0.0"
+            }
+        },
+        "node_modules/@emmetio/scanner": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+            "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@emmetio/stream-reader": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+            "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@emmetio/stream-reader-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+            "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@emnapi/runtime": {
             "version": "1.10.0",
@@ -1637,6 +1809,13 @@
                 "@types/unist": "*"
             }
         },
+        "node_modules/@types/katex": {
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+            "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/mdast": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -1672,6 +1851,172 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
             "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
             "license": "ISC"
+        },
+        "node_modules/@volar/kit": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+            "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@volar/language-service": "2.4.28",
+                "@volar/typescript": "2.4.28",
+                "typesafe-path": "^0.2.2",
+                "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-uri": "^3.0.8"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            }
+        },
+        "node_modules/@volar/language-core": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+            "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@volar/source-map": "2.4.28"
+            }
+        },
+        "node_modules/@volar/language-server": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+            "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@volar/language-core": "2.4.28",
+                "@volar/language-service": "2.4.28",
+                "@volar/typescript": "2.4.28",
+                "path-browserify": "^1.0.1",
+                "request-light": "^0.7.0",
+                "vscode-languageserver": "^9.0.1",
+                "vscode-languageserver-protocol": "^3.17.5",
+                "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-uri": "^3.0.8"
+            }
+        },
+        "node_modules/@volar/language-service": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+            "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@volar/language-core": "2.4.28",
+                "vscode-languageserver-protocol": "^3.17.5",
+                "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-uri": "^3.0.8"
+            }
+        },
+        "node_modules/@volar/source-map": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+            "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@volar/typescript": {
+            "version": "2.4.28",
+            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+            "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@volar/language-core": "2.4.28",
+                "path-browserify": "^1.0.1",
+                "vscode-uri": "^3.0.8"
+            }
+        },
+        "node_modules/@vscode/emmet-helper": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+            "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emmet": "^2.4.3",
+                "jsonc-parser": "^2.3.0",
+                "vscode-languageserver-textdocument": "^1.0.1",
+                "vscode-languageserver-types": "^3.15.1",
+                "vscode-uri": "^3.0.8"
+            }
+        },
+        "node_modules/@vscode/emmet-helper/node_modules/jsonc-parser": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+            "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vscode/l10n": {
+            "version": "0.0.18",
+            "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+            "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/ajv-draft-04": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+            "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "ajv": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
@@ -1820,11 +2165,34 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "license": "ISC"
+        },
+        "node_modules/brace-expansion": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/ccount": {
             "version": "2.0.1",
@@ -1866,6 +2234,17 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/character-reference-invalid": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/chokidar": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -1896,6 +2275,59 @@
                 "node": ">=8"
             }
         },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/cliui/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/clsx": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1904,6 +2336,26 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
@@ -2065,6 +2517,16 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/defu": {
             "version": "6.1.7",
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -2200,6 +2662,30 @@
                 "node": ">=4"
             }
         },
+        "node_modules/emmet": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+            "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+            "dev": true,
+            "license": "MIT",
+            "workspaces": [
+                "./packages/scanner",
+                "./packages/abbreviation",
+                "./packages/css-abbreviation",
+                "./"
+            ],
+            "dependencies": {
+                "@emmetio/abbreviation": "^2.3.3",
+                "@emmetio/css-abbreviation": "^2.1.8"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/entities": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2259,6 +2745,16 @@
                 "@esbuild/win32-x64": "0.27.7"
             }
         },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/escape-string-regexp": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -2289,6 +2785,13 @@
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "license": "MIT"
         },
+        "node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/fast-string-truncated-width": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -2303,6 +2806,23 @@
             "dependencies": {
                 "fast-string-truncated-width": "^3.0.2"
             }
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fast-wrap-ansi": {
             "version": "0.2.2",
@@ -2372,6 +2892,29 @@
             ],
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+            "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-tsconfig": {
@@ -2609,6 +3152,26 @@
             "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
             "license": "BSD-2-Clause"
         },
+        "node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/ini": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
+            "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/iron-webcrypto": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
@@ -2616,6 +3179,43 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/brc-dd"
+            }
+        },
+        "node_modules/is-alphabetical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-alphanumerical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-alphabetical": "^2.0.0",
+                "is-decimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-decimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-docker": {
@@ -2631,6 +3231,27 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-hexadecimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-inside-container": {
@@ -2705,11 +3326,85 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/jsonc-parser": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
             "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
             "license": "MIT"
+        },
+        "node_modules/jsonpointer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+            "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/katex": {
+            "version": "0.16.47",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+            "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+            "dev": true,
+            "funding": [
+                "https://opencollective.com/katex",
+                "https://github.com/sponsors/katex"
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "commander": "^8.3.0"
+            },
+            "bin": {
+                "katex": "cli.js"
+            }
+        },
+        "node_modules/katex/node_modules/commander": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/kleur": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+            "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/linkify-it": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "uc.micro": "^2.0.0"
+            }
         },
         "node_modules/longest-streak": {
             "version": "3.1.0",
@@ -2750,6 +3445,37 @@
                 "source-map-js": "^1.2.1"
             }
         },
+        "node_modules/markdown-it": {
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "node_modules/markdown-it/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/markdown-table": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -2758,6 +3484,67 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/markdownlint": {
+            "version": "0.40.0",
+            "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+            "integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "micromark": "4.0.2",
+                "micromark-core-commonmark": "2.0.3",
+                "micromark-extension-directive": "4.0.0",
+                "micromark-extension-gfm-autolink-literal": "2.1.0",
+                "micromark-extension-gfm-footnote": "2.1.0",
+                "micromark-extension-gfm-table": "2.1.1",
+                "micromark-extension-math": "3.1.0",
+                "micromark-util-types": "2.0.2",
+                "string-width": "8.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/DavidAnson"
+            }
+        },
+        "node_modules/markdownlint-cli": {
+            "version": "0.48.0",
+            "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.48.0.tgz",
+            "integrity": "sha512-NkZQNu2E0Q5qLEEHwWj674eYISTLD4jMHkBzDobujXd1kv+yCxi8jOaD/rZoQNW1FBBMMGQpuW5So8B51N/e0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "commander": "~14.0.3",
+                "deep-extend": "~0.6.0",
+                "ignore": "~7.0.5",
+                "js-yaml": "~4.1.1",
+                "jsonc-parser": "~3.3.1",
+                "jsonpointer": "~5.0.1",
+                "markdown-it": "~14.1.1",
+                "markdownlint": "~0.40.0",
+                "minimatch": "~10.2.4",
+                "run-con": "~1.3.2",
+                "smol-toml": "~1.6.0",
+                "tinyglobby": "~0.2.15"
+            },
+            "bin": {
+                "markdownlint": "markdownlint.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/markdownlint-cli/node_modules/commander": {
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/mdast-util-definitions": {
@@ -2991,6 +3778,13 @@
             "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "license": "CC0-1.0"
         },
+        "node_modules/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/micromark": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -3058,6 +3852,26 @@
                 "micromark-util-subtokenize": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-directive": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+            "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "parse-entities": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/micromark-extension-gfm": {
@@ -3171,6 +3985,26 @@
             "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-math": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+            "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/katex": "^0.16.0",
+                "devlop": "^1.0.0",
+                "katex": "^0.16.0",
                 "micromark-factory-space": "^2.0.0",
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0",
@@ -3554,6 +4388,32 @@
             ],
             "license": "MIT"
         },
+        "node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/mrmime": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -3567,6 +4427,13 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/muggle-string": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+            "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/nanoid": {
@@ -3735,6 +4602,33 @@
             "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
             "license": "MIT"
         },
+        "node_modules/parse-entities": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "character-entities-legacy": "^3.0.0",
+                "character-reference-invalid": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "is-alphanumerical": "^2.0.0",
+                "is-decimal": "^2.0.0",
+                "is-hexadecimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/parse-entities/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/parse-latin": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -3764,6 +4658,13 @@
             "funding": {
                 "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
+        },
+        "node_modules/path-browserify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+            "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/piccolore": {
             "version": "0.1.3",
@@ -3817,6 +4718,22 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
+        "node_modules/prettier": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/prismjs": {
             "version": "1.30.0",
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
@@ -3834,6 +4751,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/radix3": {
@@ -4021,6 +4948,33 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/request-light": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+            "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4140,6 +5094,22 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "license": "MIT"
+        },
+        "node_modules/run-con": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.3.2.tgz",
+            "integrity": "sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==",
+            "dev": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~4.1.0",
+                "minimist": "^1.2.8",
+                "strip-json-comments": "~3.1.1"
+            },
+            "bin": {
+                "run-con": "cli.js"
+            }
         },
         "node_modules/sax": {
             "version": "1.6.0",
@@ -4263,6 +5233,23 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/string-width": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+            "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.3.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/stringify-entities": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -4275,6 +5262,35 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+            "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.2.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/svgo": {
@@ -4369,6 +5385,13 @@
             "license": "0BSD",
             "optional": true
         },
+        "node_modules/typesafe-path": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+            "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/typescript": {
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4382,6 +5405,23 @@
             "engines": {
                 "node": ">=14.17"
             }
+        },
+        "node_modules/typescript-auto-import-cache": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+            "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.3.8"
+            }
+        },
+        "node_modules/uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ufo": {
             "version": "1.6.4",
@@ -4785,6 +5825,254 @@
                 }
             }
         },
+        "node_modules/volar-service-css": {
+            "version": "0.0.70",
+            "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.70.tgz",
+            "integrity": "sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vscode-css-languageservice": "^6.3.0",
+                "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-uri": "^3.0.8"
+            },
+            "peerDependencies": {
+                "@volar/language-service": "~2.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@volar/language-service": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/volar-service-emmet": {
+            "version": "0.0.70",
+            "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.70.tgz",
+            "integrity": "sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@emmetio/css-parser": "^0.4.1",
+                "@emmetio/html-matcher": "^1.3.0",
+                "@vscode/emmet-helper": "^2.9.3",
+                "vscode-uri": "^3.0.8"
+            },
+            "peerDependencies": {
+                "@volar/language-service": "~2.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@volar/language-service": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/volar-service-html": {
+            "version": "0.0.70",
+            "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.70.tgz",
+            "integrity": "sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vscode-html-languageservice": "^5.3.0",
+                "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-uri": "^3.0.8"
+            },
+            "peerDependencies": {
+                "@volar/language-service": "~2.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@volar/language-service": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/volar-service-prettier": {
+            "version": "0.0.70",
+            "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.70.tgz",
+            "integrity": "sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vscode-uri": "^3.0.8"
+            },
+            "peerDependencies": {
+                "@volar/language-service": "~2.4.0",
+                "prettier": "^2.2 || ^3.0"
+            },
+            "peerDependenciesMeta": {
+                "@volar/language-service": {
+                    "optional": true
+                },
+                "prettier": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/volar-service-typescript": {
+            "version": "0.0.70",
+            "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.70.tgz",
+            "integrity": "sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-browserify": "^1.0.1",
+                "semver": "^7.6.2",
+                "typescript-auto-import-cache": "^0.3.5",
+                "vscode-languageserver-textdocument": "^1.0.11",
+                "vscode-nls": "^5.2.0",
+                "vscode-uri": "^3.0.8"
+            },
+            "peerDependencies": {
+                "@volar/language-service": "~2.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@volar/language-service": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/volar-service-typescript-twoslash-queries": {
+            "version": "0.0.70",
+            "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.70.tgz",
+            "integrity": "sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vscode-uri": "^3.0.8"
+            },
+            "peerDependencies": {
+                "@volar/language-service": "~2.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@volar/language-service": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/volar-service-yaml": {
+            "version": "0.0.70",
+            "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.70.tgz",
+            "integrity": "sha512-0c8bXDBeoATF9F6iPIlOuYTuZAC4c+yi0siQo920u7eiBJk8oQmUmg9cDUbR4+Gl++bvGP4plj3fErbJuPqdcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vscode-uri": "^3.0.8",
+                "yaml-language-server": "~1.20.0"
+            },
+            "peerDependencies": {
+                "@volar/language-service": "~2.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@volar/language-service": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vscode-css-languageservice": {
+            "version": "6.3.10",
+            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+            "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/l10n": "^0.0.18",
+                "vscode-languageserver-textdocument": "^1.0.12",
+                "vscode-languageserver-types": "3.17.5",
+                "vscode-uri": "^3.1.0"
+            }
+        },
+        "node_modules/vscode-html-languageservice": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+            "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/l10n": "^0.0.18",
+                "vscode-languageserver-textdocument": "^1.0.12",
+                "vscode-languageserver-types": "^3.17.5",
+                "vscode-uri": "^3.1.0"
+            }
+        },
+        "node_modules/vscode-json-languageservice": {
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+            "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jsonc-parser": "^3.0.0",
+                "vscode-languageserver-textdocument": "^1.0.1",
+                "vscode-languageserver-types": "^3.16.0",
+                "vscode-nls": "^5.0.0",
+                "vscode-uri": "^3.0.2"
+            },
+            "engines": {
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageserver": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+            "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vscode-languageserver-protocol": "3.17.5"
+            },
+            "bin": {
+                "installServerIntoExtension": "bin/installServerIntoExtension"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
+            }
+        },
+        "node_modules/vscode-languageserver-textdocument": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vscode-nls": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+            "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/vscode-uri": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+            "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/web-namespaces": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -4804,11 +6092,155 @@
                 "node": ">=4"
             }
         },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/xxhash-wasm": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
             "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
             "license": "MIT"
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "devOptional": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
+        "node_modules/yaml-language-server": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.20.0.tgz",
+            "integrity": "sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vscode/l10n": "^0.0.18",
+                "ajv": "^8.17.1",
+                "ajv-draft-04": "^1.0.0",
+                "prettier": "^3.5.0",
+                "request-light": "^0.5.7",
+                "vscode-json-languageservice": "4.1.8",
+                "vscode-languageserver": "^9.0.0",
+                "vscode-languageserver-textdocument": "^1.0.1",
+                "vscode-languageserver-types": "^3.16.0",
+                "vscode-uri": "^3.0.2",
+                "yaml": "2.7.1"
+            },
+            "bin": {
+                "yaml-language-server": "bin/yaml-language-server"
+            }
+        },
+        "node_modules/yaml-language-server/node_modules/request-light": {
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+            "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/yaml-language-server/node_modules/yaml": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+            "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/yargs-parser": {
             "version": "22.0.0",
@@ -4817,6 +6249,54 @@
             "license": "ISC",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
+            }
+        },
+        "node_modules/yargs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,368 +8,113 @@
             "name": "@example/basics",
             "version": "0.0.1",
             "dependencies": {
-                "astro": "^2.10.9"
-            }
-        },
-        "node_modules/@ampproject/remapping": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "astro": "^6.4.2"
             },
-            "engines": {
-                "node": ">=6.0.0"
+            "devDependencies": {
+                "typescript": "^5.8.3"
             }
         },
         "node_modules/@astrojs/compiler": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-1.8.1.tgz",
-            "integrity": "sha512-C28qplQzgIJ+JU9S+1wNx+ue2KCBUp0TTAd10EWAEkk4RsL3Tzlw0BYvLDDb4KP9jS48lXmR4/1TtZ4aavYJ8Q=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+            "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
+            "license": "MIT"
         },
         "node_modules/@astrojs/internal-helpers": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.1.2.tgz",
-            "integrity": "sha512-YXLk1CUDdC9P5bjFZcGjz+cE/ZDceXObDTXn/GCID4r8LjThuexxi+dlJqukmUpkSItzQqgzfWnrPLxSFPejdA=="
-        },
-        "node_modules/@astrojs/language-server": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-1.0.8.tgz",
-            "integrity": "sha512-gssRxLGb8XnvKpqSzrDW5jdzdFnXD7eBXVkPCkkt2hv7Qzb+SAzv6hVgMok3jDCxpR1aeB+XNd9Qszj2h29iog==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.0.tgz",
+            "integrity": "sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==",
+            "license": "MIT",
             "dependencies": {
-                "@astrojs/compiler": "^1.4.2",
-                "@jridgewell/trace-mapping": "^0.3.14",
-                "@vscode/emmet-helper": "^2.8.4",
-                "events": "^3.3.0",
-                "prettier": "^2.8.8",
-                "prettier-plugin-astro": "^0.9.1",
-                "vscode-css-languageservice": "^6.2.1",
-                "vscode-html-languageservice": "^5.0.0",
-                "vscode-languageserver": "^8.0.1",
-                "vscode-languageserver-protocol": "^3.17.1",
-                "vscode-languageserver-textdocument": "^1.0.4",
-                "vscode-languageserver-types": "^3.17.1",
-                "vscode-uri": "^3.0.3"
-            },
-            "bin": {
-                "astro-ls": "bin/nodeServer.js"
+                "@types/hast": "^3.0.4",
+                "@types/mdast": "^4.0.4",
+                "js-yaml": "^4.1.1",
+                "picomatch": "^4.0.4",
+                "retext-smartypants": "^6.2.0",
+                "shiki": "^4.0.2",
+                "smol-toml": "^1.6.0",
+                "unified": "^11.0.5"
             }
         },
         "node_modules/@astrojs/markdown-remark": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-2.2.1.tgz",
-            "integrity": "sha512-VF0HRv4GpC1XEMLnsKf6jth7JSmlt9qpqP0josQgA2eSpCIAC/Et+y94mgdBIZVBYH/yFnMoIxgKVe93xfO2GA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.0.tgz",
+            "integrity": "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==",
+            "license": "MIT",
             "dependencies": {
-                "@astrojs/prism": "^2.1.2",
-                "github-slugger": "^1.4.0",
-                "import-meta-resolve": "^2.1.0",
-                "rehype-raw": "^6.1.1",
-                "rehype-stringify": "^9.0.3",
-                "remark-gfm": "^3.0.1",
-                "remark-parse": "^10.0.1",
-                "remark-rehype": "^10.1.0",
-                "remark-smartypants": "^2.0.0",
-                "shiki": "^0.14.1",
-                "unified": "^10.1.2",
-                "unist-util-visit": "^4.1.0",
-                "vfile": "^5.3.2"
-            },
-            "peerDependencies": {
-                "astro": "^2.5.0"
+                "@astrojs/internal-helpers": "0.10.0",
+                "@astrojs/prism": "4.0.2",
+                "github-slugger": "^2.0.0",
+                "hast-util-from-html": "^2.0.3",
+                "hast-util-to-text": "^4.0.2",
+                "mdast-util-definitions": "^6.0.0",
+                "rehype-raw": "^7.0.0",
+                "rehype-stringify": "^10.0.1",
+                "remark-gfm": "^4.0.1",
+                "remark-parse": "^11.0.0",
+                "remark-rehype": "^11.1.2",
+                "remark-smartypants": "^3.0.2",
+                "unified": "^11.0.5",
+                "unist-util-remove-position": "^5.0.0",
+                "unist-util-visit": "^5.1.0",
+                "unist-util-visit-parents": "^6.0.2",
+                "vfile": "^6.0.3"
             }
         },
-        "node_modules/@astrojs/markdown-remark/node_modules/github-slugger": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.5.0.tgz",
-            "integrity": "sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw=="
-        },
         "node_modules/@astrojs/prism": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-2.1.2.tgz",
-            "integrity": "sha512-3antim1gb34689GHRQFJ88JEo93HuZKQBnmxDT5W/nxiNz1p/iRxnCTEhIbJhqMOTRbbo5h2ldm5qSxx+TMFQA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
+            "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
+            "license": "MIT",
             "dependencies": {
-                "prismjs": "^1.28.0"
+                "prismjs": "^1.30.0"
             },
             "engines": {
-                "node": ">=16.12.0"
+                "node": ">=22.12.0"
             }
         },
         "node_modules/@astrojs/telemetry": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-2.1.1.tgz",
-            "integrity": "sha512-4pRhyeQr0MLB5PKYgkdu+YE8sSpMbHL8dUuslBWBIdgcYjtD1SufPMBI8pgXJ+xlwrQJHKKfK2X1KonHYuOS9A==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.2.tgz",
+            "integrity": "sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==",
+            "license": "MIT",
             "dependencies": {
-                "ci-info": "^3.3.1",
-                "debug": "^4.3.4",
-                "dlv": "^1.1.3",
-                "dset": "^3.1.2",
-                "is-docker": "^3.0.0",
-                "is-wsl": "^2.2.0",
-                "undici": "^5.22.0",
+                "ci-info": "^4.4.0",
+                "dset": "^3.1.4",
+                "is-docker": "^4.0.0",
+                "is-wsl": "^3.1.1",
                 "which-pm-runs": "^1.1.0"
             },
             "engines": {
-                "node": ">=16.12.0"
-            }
-        },
-        "node_modules/@astrojs/webapi": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/webapi/-/webapi-2.2.0.tgz",
-            "integrity": "sha512-mHAOApWyjqSe5AQMOUD9rsZJqbMQqe3Wosb1a40JV6Okvyxj1G6GTlthwYadWCymq/lbgwh0PLiY8Fr4eFxtuQ==",
-            "dependencies": {
-                "undici": "^5.22.0"
-            }
-        },
-        "node_modules/@babel/code-frame": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-            "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
-            "dependencies": {
-                "@babel/highlight": "^7.22.10",
-                "chalk": "^2.4.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/compat-data": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-            "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/core": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
-            "integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
-            "dependencies": {
-                "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-compilation-targets": "^7.22.10",
-                "@babel/helper-module-transforms": "^7.22.9",
-                "@babel/helpers": "^7.22.10",
-                "@babel/parser": "^7.22.10",
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.10",
-                "@babel/types": "^7.22.10",
-                "convert-source-map": "^1.7.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.2",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@babel/generator": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-            "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
-            "dependencies": {
-                "@babel/types": "^7.22.10",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
-                "jsesc": "^2.5.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-            "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-            "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
-            "dependencies": {
-                "@babel/compat-data": "^7.22.9",
-                "@babel/helper-validator-option": "^7.22.5",
-                "browserslist": "^4.21.9",
-                "lru-cache": "^5.1.1",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
-            "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-imports": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-            "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-transforms": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-            "integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
-            "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-module-imports": "^7.22.5",
-                "@babel/helper-simple-access": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/helper-validator-identifier": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-            "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-simple-access": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-            "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+                "node": "18.20.8 || ^20.3.0 || >=22.0.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-validator-option": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-            "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helpers": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
-            "integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
-            "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.10",
-                "@babel/types": "^7.22.10"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/highlight": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-            "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.5",
-                "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
-            },
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
-            "integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+            "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.29.7"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -377,742 +122,1562 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-            "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz",
-            "integrity": "sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==",
-            "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-module-imports": "^7.22.5",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/plugin-syntax-jsx": "^7.22.5",
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/template": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-            "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
-            "dependencies": {
-                "@babel/code-frame": "^7.22.5",
-                "@babel/parser": "^7.22.5",
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/traverse": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
-            "integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
-            "dependencies": {
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.10",
-                "@babel/types": "^7.22.10",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/types": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
-            "integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+            "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5",
-                "to-fast-properties": "^2.0.0"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@emmetio/abbreviation": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
-            "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+        "node_modules/@capsizecss/unpack": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
+            "integrity": "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==",
+            "license": "MIT",
             "dependencies": {
-                "@emmetio/scanner": "^1.0.4"
+                "fontkitten": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
-        "node_modules/@emmetio/css-abbreviation": {
-            "version": "2.1.8",
-            "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
-            "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+        "node_modules/@clack/core": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.1.tgz",
+            "integrity": "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==",
+            "license": "MIT",
             "dependencies": {
-                "@emmetio/scanner": "^1.0.4"
-            }
-        },
-        "node_modules/@emmetio/scanner": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
-            "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
-        },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-            "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
+                "fast-wrap-ansi": "^0.2.0",
+                "sisteransi": "^1.0.5"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">= 20.12.0"
             }
         },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-            "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
+        "node_modules/@clack/prompts": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.4.0.tgz",
+            "integrity": "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==",
+            "license": "MIT",
+            "dependencies": {
+                "@clack/core": "1.3.1",
+                "fast-string-width": "^3.0.2",
+                "fast-wrap-ansi": "^0.2.0",
+                "sisteransi": "^1.0.5"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">= 20.12.0"
             }
         },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-            "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
-            "cpu": [
-                "x64"
-            ],
+        "node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-            "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-            "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-            "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-            "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-            "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-            "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-            "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-            "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
-            "cpu": [
-                "loong64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-            "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
-            "cpu": [
-                "mips64el"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-            "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
             "cpu": [
                 "ppc64"
             ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-            "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
             "cpu": [
                 "riscv64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-            "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
             "cpu": [
                 "s390x"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-            "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-            "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
             "cpu": [
-                "x64"
+                "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "netbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-            "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "openbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-            "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "sunos"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-            "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
             "cpu": [
                 "arm64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-            "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
             "cpu": [
                 "ia32"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-            "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
             "cpu": [
                 "x64"
             ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
-        "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+        "node_modules/@img/colour": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+            "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+            "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+            "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+            "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+            "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+            "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+            "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+            "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-riscv64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+            "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+            "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+            "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+            "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+            "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+            "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+            "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-ppc64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+            "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-ppc64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-riscv64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+            "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-riscv64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+            "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+            "cpu": [
+                "s390x"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+            "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+            "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+            "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+            "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
-                "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@emnapi/runtime": "^1.7.0"
             },
             "engines": {
-                "node": ">=6.0.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
-        "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+        "node_modules/@img/sharp-win32-arm64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+            "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
             "engines": {
-                "node": ">=6.0.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
-        "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+            "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
             "engines": {
-                "node": ">=6.0.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+            "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "license": "MIT"
         },
-        "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.1.0",
-                "@jridgewell/sourcemap-codec": "^1.4.14"
-            }
+        "node_modules/@oslojs/encoding": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
+            "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+            "license": "MIT"
         },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+            "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+            "license": "MIT",
             "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "engines": {
-                "node": ">= 8"
-            }
+        "node_modules/@rollup/rollup-android-arm-eabi": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+            "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
         },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+        "node_modules/@rollup/rollup-android-arm64": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+            "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-arm64": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+            "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-darwin-x64": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+            "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+            "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+            "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+            "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+            "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+            "cpu": [
+                "arm"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-gnu": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+            "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-arm64-musl": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+            "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+            "cpu": [
+                "arm64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+            "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+            "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+            "cpu": [
+                "loong64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+            "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+            "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+            "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-riscv64-musl": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+            "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-s390x-gnu": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+            "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-gnu": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+            "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-x64-musl": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+            "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+            "cpu": [
+                "x64"
+            ],
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+            "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+            "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-arm64-msvc": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+            "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-ia32-msvc": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+            "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+            "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rollup/rollup-win32-x64-msvc": {
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+            "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@shikijs/core": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.1.0.tgz",
+            "integrity": "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==",
+            "license": "MIT",
             "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
+                "@shikijs/primitive": "4.1.0",
+                "@shikijs/types": "4.1.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4",
+                "hast-util-to-html": "^9.0.5"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">=20"
             }
         },
-        "node_modules/@pkgr/utils": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.2.tgz",
-            "integrity": "sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==",
+        "node_modules/@shikijs/engine-javascript": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.1.0.tgz",
+            "integrity": "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==",
+            "license": "MIT",
             "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "fast-glob": "^3.3.0",
-                "is-glob": "^4.0.3",
-                "open": "^9.1.0",
-                "picocolors": "^1.0.0",
-                "tslib": "^2.6.0"
+                "@shikijs/types": "4.1.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "oniguruma-to-es": "^4.3.6"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+                "node": ">=20"
+            }
+        },
+        "node_modules/@shikijs/engine-oniguruma": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.1.0.tgz",
+            "integrity": "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==",
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "4.1.0",
+                "@shikijs/vscode-textmate": "^10.0.2"
             },
-            "funding": {
-                "url": "https://opencollective.com/unts"
+            "engines": {
+                "node": ">=20"
             }
         },
-        "node_modules/@types/babel__core": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.1.tgz",
-            "integrity": "sha512-aACu/U/omhdk15O4Nfb+fHgH/z3QsfQzpnvRZhYhThms83ZnAOZz7zZAWO7mn2yyNQaA4xTO8GLK3uqFU4bYYw==",
+        "node_modules/@shikijs/langs": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.1.0.tgz",
+            "integrity": "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.20.7",
-                "@babel/types": "^7.20.7",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
+                "@shikijs/types": "4.1.0"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
-        "node_modules/@types/babel__generator": {
-            "version": "7.6.4",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
-            "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+        "node_modules/@shikijs/primitive": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.1.0.tgz",
+            "integrity": "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.0.0"
+                "@shikijs/types": "4.1.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
-        "node_modules/@types/babel__template": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
-            "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+        "node_modules/@shikijs/themes": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.1.0.tgz",
+            "integrity": "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@shikijs/types": "4.1.0"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
-        "node_modules/@types/babel__traverse": {
-            "version": "7.20.1",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.1.tgz",
-            "integrity": "sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==",
+        "node_modules/@shikijs/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==",
+            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.20.7"
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
             }
+        },
+        "node_modules/@shikijs/vscode-textmate": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+            "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+            "license": "MIT"
         },
         "node_modules/@types/debug": {
-            "version": "4.1.8",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-            "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+            "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/ms": "*"
             }
         },
-        "node_modules/@types/dom-view-transitions": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/dom-view-transitions/-/dom-view-transitions-1.0.1.tgz",
-            "integrity": "sha512-A9S1ijj/4MX06I1W/6on8lhaYyq1Ir7gaOvfllW1o4RzVWW88HAeqX0pUx9VgOLnNpdiGeUW2CTkg18p5LWIrA=="
+        "node_modules/@types/estree": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "license": "MIT"
         },
         "node_modules/@types/hast": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.5.tgz",
-            "integrity": "sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2"
+                "@types/unist": "*"
             }
         },
-        "node_modules/@types/json5": {
-            "version": "0.0.30",
-            "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.30.tgz",
-            "integrity": "sha512-sqm9g7mHlPY/43fcSNrCYfOeX9zkTTK+euO5E6+CVijSMm5tTjkVdwdqRkY3ljjIAf8679vps5jKUoJBCLsMDA=="
-        },
         "node_modules/@types/mdast": {
-            "version": "3.0.12",
-            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
-            "integrity": "sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+            "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2"
+                "@types/unist": "*"
             }
         },
         "node_modules/@types/ms": {
-            "version": "0.7.31",
-            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+            "license": "MIT"
         },
         "node_modules/@types/nlcst": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-1.0.1.tgz",
-            "integrity": "sha512-aVIyXt6pZiiMOtVByE4Y0gf+BLm1Cxc4ZLSK8VRHn1CgkO+kXbQwN/EBhQmhPdBMjFJCMBKtmNW2zWQuFywz8Q==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+            "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2"
+                "@types/unist": "*"
             }
-        },
-        "node_modules/@types/parse5": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
-            "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g=="
-        },
-        "node_modules/@types/resolve": {
-            "version": "1.20.2",
-            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
-            "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="
         },
         "node_modules/@types/unist": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.7.tgz",
-            "integrity": "sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g=="
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "license": "MIT"
         },
-        "node_modules/@types/yargs-parser": {
-            "version": "21.0.0",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-            "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
-        },
-        "node_modules/@vscode/emmet-helper": {
-            "version": "2.9.2",
-            "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.9.2.tgz",
-            "integrity": "sha512-MaGuyW+fa13q3aYsluKqclmh62Hgp0BpKIqS66fCxfOaBcVQ1OnMQxRRgQUYnCkxFISAQlkJ0qWWPyXjro1Qrg==",
-            "dependencies": {
-                "emmet": "^2.4.3",
-                "jsonc-parser": "^2.3.0",
-                "vscode-languageserver-textdocument": "^1.0.1",
-                "vscode-languageserver-types": "^3.15.1",
-                "vscode-uri": "^2.1.2"
-            }
-        },
-        "node_modules/@vscode/emmet-helper/node_modules/vscode-uri": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz",
-            "integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A=="
-        },
-        "node_modules/@vscode/l10n": {
-            "version": "0.0.14",
-            "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.14.tgz",
-            "integrity": "sha512-/yrv59IEnmh655z1oeDnGcvMYwnEzNzHLgeYcQCkhYX0xBvYWrAuefoiLcPBUkMpJsb46bqQ6Yv4pwTTQ4d3Qg=="
-        },
-        "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/ansi-align": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-            "dependencies": {
-                "string-width": "^4.1.0"
-            }
-        },
-        "node_modules/ansi-align/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ansi-align/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/ansi-align/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ansi-align/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-            }
-        },
-        "node_modules/ansi-sequence-parser": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-            "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
-        },
-        "node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+            "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+            "license": "ISC"
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "license": "ISC",
             "dependencies": {
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
@@ -1121,395 +1686,161 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/anymatch/node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+            "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/array-iterate": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
             "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/astro": {
-            "version": "2.10.9",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-2.10.9.tgz",
-            "integrity": "sha512-rtm/RHeJdAIAsziQaAGvbv2ALylNNOF1SUQ0zJaugu/ABUU62tNGNSxIR0LO5l4+dHhLbzRNo5uEnIPkmSRw+w==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.2.tgz",
+            "integrity": "sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==",
+            "license": "MIT",
             "dependencies": {
-                "@astrojs/compiler": "^1.8.0",
-                "@astrojs/internal-helpers": "^0.1.2",
-                "@astrojs/language-server": "^1.0.0",
-                "@astrojs/markdown-remark": "^2.2.1",
-                "@astrojs/telemetry": "^2.1.1",
-                "@astrojs/webapi": "^2.2.0",
-                "@babel/core": "^7.22.5",
-                "@babel/generator": "^7.22.5",
-                "@babel/parser": "^7.22.5",
-                "@babel/plugin-transform-react-jsx": "^7.22.5",
-                "@babel/traverse": "^7.22.5",
-                "@babel/types": "^7.22.5",
-                "@types/babel__core": "^7.20.1",
-                "@types/dom-view-transitions": "^1.0.1",
-                "@types/yargs-parser": "^21.0.0",
-                "acorn": "^8.9.0",
-                "boxen": "^6.2.1",
-                "chokidar": "^3.5.3",
-                "ci-info": "^3.8.0",
-                "common-ancestor-path": "^1.0.1",
-                "cookie": "^0.5.0",
-                "debug": "^4.3.4",
-                "devalue": "^4.3.2",
-                "diff": "^5.1.0",
-                "es-module-lexer": "^1.3.0",
-                "esbuild": "^0.17.19",
-                "estree-walker": "3.0.0",
-                "execa": "^6.1.0",
-                "fast-glob": "^3.2.12",
+                "@astrojs/compiler": "^4.0.0",
+                "@astrojs/internal-helpers": "0.10.0",
+                "@astrojs/markdown-remark": "7.2.0",
+                "@astrojs/telemetry": "3.3.2",
+                "@capsizecss/unpack": "^4.0.0",
+                "@clack/prompts": "^1.1.0",
+                "@oslojs/encoding": "^1.1.0",
+                "@rollup/pluginutils": "^5.3.0",
+                "aria-query": "^5.3.2",
+                "axobject-query": "^4.1.0",
+                "ci-info": "^4.4.0",
+                "clsx": "^2.1.1",
+                "common-ancestor-path": "^2.0.0",
+                "cookie": "^1.1.1",
+                "devalue": "^5.6.3",
+                "diff": "^8.0.3",
+                "dset": "^3.1.4",
+                "es-module-lexer": "^2.0.0",
+                "esbuild": "^0.27.3",
+                "flattie": "^1.1.1",
+                "fontace": "~0.4.1",
+                "get-tsconfig": "5.0.0-beta.4",
                 "github-slugger": "^2.0.0",
-                "gray-matter": "^4.0.3",
-                "html-escaper": "^3.0.3",
-                "js-yaml": "^4.1.0",
-                "kleur": "^4.1.4",
-                "magic-string": "^0.30.2",
-                "mime": "^3.0.0",
-                "network-information-types": "^0.1.1",
-                "ora": "^6.3.1",
-                "p-limit": "^4.0.0",
-                "path-to-regexp": "^6.2.1",
-                "preferred-pm": "^3.0.3",
-                "prompts": "^2.4.2",
-                "rehype": "^12.0.1",
-                "semver": "^7.5.3",
-                "server-destroy": "^1.0.1",
-                "shiki": "^0.14.1",
-                "string-width": "^5.1.2",
-                "strip-ansi": "^7.1.0",
-                "tsconfig-resolver": "^3.0.1",
-                "typescript": "*",
-                "unist-util-visit": "^4.1.2",
-                "vfile": "^5.3.7",
-                "vite": "^4.4.6",
-                "vitefu": "^0.2.4",
-                "which-pm": "^2.0.0",
-                "yargs-parser": "^21.1.1",
-                "zod": "^3.20.6"
+                "html-escaper": "3.0.3",
+                "http-cache-semantics": "^4.2.0",
+                "js-yaml": "^4.1.1",
+                "jsonc-parser": "^3.3.1",
+                "magic-string": "^0.30.21",
+                "magicast": "^0.5.2",
+                "mrmime": "^2.0.1",
+                "neotraverse": "^0.6.18",
+                "obug": "^2.1.1",
+                "p-limit": "^7.3.0",
+                "p-queue": "^9.1.0",
+                "package-manager-detector": "^1.6.0",
+                "piccolore": "^0.1.3",
+                "picomatch": "^4.0.4",
+                "rehype": "^13.0.2",
+                "semver": "^7.7.4",
+                "shiki": "^4.0.2",
+                "smol-toml": "^1.6.0",
+                "svgo": "^4.0.1",
+                "tinyclip": "^0.1.12",
+                "tinyexec": "^1.0.4",
+                "tinyglobby": "^0.2.15",
+                "ultrahtml": "^1.6.0",
+                "unifont": "~0.7.4",
+                "unist-util-visit": "^5.1.0",
+                "unstorage": "^1.17.5",
+                "vfile": "^6.0.3",
+                "vite": "^7.3.2",
+                "vitefu": "^1.1.2",
+                "xxhash-wasm": "^1.1.0",
+                "yargs-parser": "^22.0.0",
+                "zod": "^4.3.6"
             },
             "bin": {
-                "astro": "astro.js"
+                "astro": "bin/astro.mjs"
             },
             "engines": {
-                "node": ">=16.12.0",
-                "npm": ">=6.14.0"
+                "node": ">=22.12.0",
+                "npm": ">=9.6.5",
+                "pnpm": ">=7.1.0"
             },
-            "peerDependencies": {
-                "sharp": ">=0.31.0"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/astrodotbuild"
             },
-            "peerDependenciesMeta": {
-                "sharp": {
-                    "optional": true
-                }
+            "optionalDependencies": {
+                "sharp": "^0.34.0"
+            }
+        },
+        "node_modules/axobject-query": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+            "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/bail": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
             "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/big-integer": {
-            "version": "1.6.51",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-            "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-            "engines": {
-                "node": ">=0.6"
-            }
-        },
-        "node_modules/binary-extensions": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/bl": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-            "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-            "dependencies": {
-                "buffer": "^6.0.3",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            }
-        },
-        "node_modules/boxen": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/boxen/-/boxen-6.2.1.tgz",
-            "integrity": "sha512-H4PEsJXfFI/Pt8sjDWbHlQPx4zL/bvSQjcilJmaulGt5mLDorHOHpmdXAJcBcmru7PhYSp/cDMWRko4ZUMFkSw==",
-            "dependencies": {
-                "ansi-align": "^3.0.1",
-                "camelcase": "^6.2.0",
-                "chalk": "^4.1.2",
-                "cli-boxes": "^3.0.0",
-                "string-width": "^5.0.1",
-                "type-fest": "^2.5.0",
-                "widest-line": "^4.0.1",
-                "wrap-ansi": "^8.0.1"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/boxen/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/boxen/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/boxen/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "node_modules/boxen/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/boxen/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/bplist-parser": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
-            "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
-            "dependencies": {
-                "big-integer": "^1.6.44"
-            },
-            "engines": {
-                "node": ">= 5.10.0"
-            }
-        },
-        "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dependencies": {
-                "fill-range": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/browserslist": {
-            "version": "4.21.10",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-            "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "dependencies": {
-                "caniuse-lite": "^1.0.30001517",
-                "electron-to-chromium": "^1.4.477",
-                "node-releases": "^2.0.13",
-                "update-browserslist-db": "^1.0.11"
-            },
-            "bin": {
-                "browserslist": "cli.js"
-            },
-            "engines": {
-                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-            }
-        },
-        "node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "node_modules/bundle-name": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
-            "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
-            "dependencies": {
-                "run-applescript": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/busboy": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-            "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-            "dependencies": {
-                "streamsearch": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=10.16.0"
-            }
-        },
-        "node_modules/camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/caniuse-lite": {
-            "version": "1.0.30001521",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
-            "integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ]
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+            "license": "ISC"
         },
         "node_modules/ccount": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
             "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/character-entities": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
             "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -1519,6 +1850,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
             "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
@@ -1528,154 +1860,188 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
             "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+            "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+            "license": "MIT",
             "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
+                "readdirp": "^5.0.0"
             },
             "engines": {
-                "node": ">= 8.10.0"
+                "node": ">= 20.19.0"
             },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/ci-info": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
-            "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/sibiraj-s"
                 }
             ],
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/cli-boxes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
-            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-            "dependencies": {
-                "restore-cursor": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cli-spinners": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
-            "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+        "node_modules/clsx": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+            "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/clone": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-            "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
-        "node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
             "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/common-ancestor-path": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz",
-            "integrity": "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="
+        "node_modules/commander": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
         },
-        "node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+        "node_modules/common-ancestor-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz",
+            "integrity": "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">= 18"
+            }
         },
         "node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+            "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 0.6"
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+        "node_modules/cookie-es": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+            "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+            "license": "MIT"
+        },
+        "node_modules/crossws": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+            "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+            "license": "MIT",
             "dependencies": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
+                "uncrypto": "^0.1.3"
+            }
+        },
+        "node_modules/css-select": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
-                "node": ">= 8"
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
             }
         },
-        "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+        "node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/csso": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "css-tree": "~2.2.0"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/css-tree": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.0.28",
+                "source-map-js": "^1.0.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/csso/node_modules/mdn-data": {
+            "version": "2.0.28",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+            "license": "CC0-1.0"
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -1687,9 +2053,10 @@
             }
         },
         "node_modules/decode-named-character-reference": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-            "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+            "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+            "license": "MIT",
             "dependencies": {
                 "character-entities": "^2.0.0"
             },
@@ -1698,331 +2065,307 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/default-browser": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
-            "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
-            "dependencies": {
-                "bundle-name": "^3.0.0",
-                "default-browser-id": "^3.0.0",
-                "execa": "^7.1.1",
-                "titleize": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser-id": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
-            "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
-            "dependencies": {
-                "bplist-parser": "^0.2.0",
-                "untildify": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/default-browser/node_modules/execa": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-            "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.1",
-                "human-signals": "^4.3.0",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^3.0.7",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/default-browser/node_modules/human-signals": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-            "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
-            "engines": {
-                "node": ">=14.18.0"
-            }
-        },
-        "node_modules/defaults": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-            "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-            "dependencies": {
-                "clone": "^1.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/define-lazy-prop": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+        "node_modules/defu": {
+            "version": "6.1.7",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+            "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+            "license": "MIT"
         },
         "node_modules/dequal": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
-        "node_modules/devalue": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.2.tgz",
-            "integrity": "sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg=="
+        "node_modules/destr": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+            "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+            "license": "MIT"
         },
-        "node_modules/diff": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-            "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/dlv": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-            "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
-        },
-        "node_modules/dset": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
-            "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-        },
-        "node_modules/electron-to-chromium": {
-            "version": "1.4.492",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.492.tgz",
-            "integrity": "sha512-36K9b/6skMVwAIEsC7GiQ8I8N3soCALVSHqWHzNDtGemAcI9Xu8hP02cywWM0A794rTHm0b0zHPeLJHtgFVamQ=="
-        },
-        "node_modules/emmet": {
-            "version": "2.4.6",
-            "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.6.tgz",
-            "integrity": "sha512-dJfbdY/hfeTyf/Ef7Y7ubLYzkBvPQ912wPaeVYpAxvFxkEBf/+hJu4H6vhAvFN6HlxqedlfVn2x1S44FfQ97pg==",
-            "dependencies": {
-                "@emmetio/abbreviation": "^2.3.3",
-                "@emmetio/css-abbreviation": "^2.1.8"
-            }
-        },
-        "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-        },
-        "node_modules/es-module-lexer": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
-            "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA=="
-        },
-        "node_modules/esbuild": {
-            "version": "0.17.19",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-            "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
-            "hasInstallScript": true,
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "optionalDependencies": {
-                "@esbuild/android-arm": "0.17.19",
-                "@esbuild/android-arm64": "0.17.19",
-                "@esbuild/android-x64": "0.17.19",
-                "@esbuild/darwin-arm64": "0.17.19",
-                "@esbuild/darwin-x64": "0.17.19",
-                "@esbuild/freebsd-arm64": "0.17.19",
-                "@esbuild/freebsd-x64": "0.17.19",
-                "@esbuild/linux-arm": "0.17.19",
-                "@esbuild/linux-arm64": "0.17.19",
-                "@esbuild/linux-ia32": "0.17.19",
-                "@esbuild/linux-loong64": "0.17.19",
-                "@esbuild/linux-mips64el": "0.17.19",
-                "@esbuild/linux-ppc64": "0.17.19",
-                "@esbuild/linux-riscv64": "0.17.19",
-                "@esbuild/linux-s390x": "0.17.19",
-                "@esbuild/linux-x64": "0.17.19",
-                "@esbuild/netbsd-x64": "0.17.19",
-                "@esbuild/openbsd-x64": "0.17.19",
-                "@esbuild/sunos-x64": "0.17.19",
-                "@esbuild/win32-arm64": "0.17.19",
-                "@esbuild/win32-ia32": "0.17.19",
-                "@esbuild/win32-x64": "0.17.19"
-            }
-        },
-        "node_modules/escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/estree-walker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
-            "integrity": "sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ=="
-        },
-        "node_modules/events": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "engines": {
-                "node": ">=0.8.x"
-            }
-        },
-        "node_modules/execa": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
-            "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.1",
-                "human-signals": "^3.0.1",
-                "is-stream": "^3.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^5.1.0",
-                "onetime": "^6.0.0",
-                "signal-exit": "^3.0.7",
-                "strip-final-newline": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/extend": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "node_modules/extend-shallow": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-            "dependencies": {
-                "is-extendable": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/fast-glob": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-            "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
-        },
-        "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "license": "Apache-2.0",
+            "optional": true,
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/find-up": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+        "node_modules/devalue": {
+            "version": "5.8.1",
+            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+            "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+            "license": "MIT"
+        },
+        "node_modules/devlop": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+            "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+            "license": "MIT",
             "dependencies": {
-                "locate-path": "^6.0.0",
-                "path-exists": "^4.0.0"
+                "dequal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/diff": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+            "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/dom-serializer/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/dset": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+            "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "license": "MIT"
+        },
+        "node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/find-yarn-workspace-root2": {
-            "version": "1.2.16",
-            "resolved": "https://registry.npmjs.org/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz",
-            "integrity": "sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==",
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "license": "MIT"
+        },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
+        },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "license": "MIT"
+        },
+        "node_modules/fast-string-truncated-width": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+            "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+            "license": "MIT"
+        },
+        "node_modules/fast-string-width": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+            "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+            "license": "MIT",
             "dependencies": {
-                "micromatch": "^4.0.2",
-                "pkg-dir": "^4.2.0"
+                "fast-string-truncated-width": "^3.0.2"
+            }
+        },
+        "node_modules/fast-wrap-ansi": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+            "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-string-width": "^3.0.2"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/flattie": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
+            "integrity": "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/fontace": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
+            "integrity": "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==",
+            "license": "MIT",
+            "dependencies": {
+                "fontkitten": "^1.0.2"
+            }
+        },
+        "node_modules/fontkitten": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
+            "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+            "license": "MIT",
+            "dependencies": {
+                "tiny-inflate": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "hasInstallScript": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -2031,28 +2374,19 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-        },
-        "node_modules/gensync": {
-            "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+        "node_modules/get-tsconfig": {
+            "version": "5.0.0-beta.4",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.4.tgz",
+            "integrity": "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==",
+            "license": "MIT",
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
             "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/get-stream": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-            "engines": {
-                "node": ">=10"
+                "node": ">=20.20.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/github-slugger": {
@@ -2060,94 +2394,54 @@
             "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
             "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
         },
-        "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+        "node_modules/h3": {
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+            "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+            "license": "MIT",
             "dependencies": {
-                "is-glob": "^4.0.1"
+                "cookie-es": "^1.2.3",
+                "crossws": "^0.3.5",
+                "defu": "^6.1.6",
+                "destr": "^2.0.5",
+                "iron-webcrypto": "^1.2.1",
+                "node-mock-http": "^1.0.4",
+                "radix3": "^1.1.2",
+                "ufo": "^1.6.3",
+                "uncrypto": "^0.1.3"
+            }
+        },
+        "node_modules/hast-util-from-html": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+            "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "devlop": "^1.1.0",
+                "hast-util-from-parse5": "^8.0.0",
+                "parse5": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-message": "^4.0.0"
             },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/globals": {
-            "version": "11.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-        },
-        "node_modules/gray-matter": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-            "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-            "dependencies": {
-                "js-yaml": "^3.13.1",
-                "kind-of": "^6.0.2",
-                "section-matter": "^1.0.0",
-                "strip-bom-string": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/gray-matter/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/gray-matter/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
-        "node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "engines": {
-                "node": ">=4"
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/hast-util-from-parse5": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-7.1.2.tgz",
-            "integrity": "sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+            "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "@types/unist": "^2.0.0",
-                "hastscript": "^7.0.0",
-                "property-information": "^6.0.0",
-                "vfile": "^5.0.0",
-                "vfile-location": "^4.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "devlop": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "property-information": "^7.0.0",
+                "vfile": "^6.0.0",
+                "vfile-location": "^5.0.0",
                 "web-namespaces": "^2.0.0"
             },
             "funding": {
@@ -2155,12 +2449,26 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/hast-util-parse-selector": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-3.1.1.tgz",
-            "integrity": "sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==",
+        "node_modules/hast-util-is-element": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+            "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0"
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-parse-selector": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2168,19 +2476,22 @@
             }
         },
         "node_modules/hast-util-raw": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-7.2.3.tgz",
-            "integrity": "sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+            "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "@types/parse5": "^6.0.0",
-                "hast-util-from-parse5": "^7.0.0",
-                "hast-util-to-parse5": "^7.0.0",
-                "html-void-elements": "^2.0.0",
-                "parse5": "^6.0.0",
-                "unist-util-position": "^4.0.0",
-                "unist-util-visit": "^4.0.0",
-                "vfile": "^5.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "hast-util-from-parse5": "^8.0.0",
+                "hast-util-to-parse5": "^8.0.0",
+                "html-void-elements": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "parse5": "^7.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0",
                 "web-namespaces": "^2.0.0",
                 "zwitch": "^2.0.0"
             },
@@ -2190,18 +2501,19 @@
             }
         },
         "node_modules/hast-util-to-html": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-8.0.4.tgz",
-            "integrity": "sha512-4tpQTUOr9BMjtYyNlt0P50mH7xj0Ks2xpo8M943Vykljf99HW6EzulIoJP1N3eKOSScEHzyzi9dm7/cn0RfGwA==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+            "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "@types/unist": "^2.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
                 "ccount": "^2.0.0",
                 "comma-separated-tokens": "^2.0.0",
-                "hast-util-raw": "^7.0.0",
-                "hast-util-whitespace": "^2.0.0",
-                "html-void-elements": "^2.0.0",
-                "property-information": "^6.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "html-void-elements": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0",
                 "stringify-entities": "^4.0.0",
                 "zwitch": "^2.0.4"
@@ -2212,13 +2524,15 @@
             }
         },
         "node_modules/hast-util-to-parse5": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-7.1.0.tgz",
-            "integrity": "sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+            "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
+                "@types/hast": "^3.0.0",
                 "comma-separated-tokens": "^2.0.0",
-                "property-information": "^6.0.0",
+                "devlop": "^1.0.0",
+                "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0",
                 "web-namespaces": "^2.0.0",
                 "zwitch": "^2.0.0"
@@ -2228,24 +2542,45 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/hast-util-to-text": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+            "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "hast-util-is-element": "^3.0.0",
+                "unist-util-find-after": "^5.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/hast-util-whitespace": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.1.tgz",
-            "integrity": "sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+            "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/hastscript": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-7.2.0.tgz",
-            "integrity": "sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
+                "@types/hast": "^3.0.0",
                 "comma-separated-tokens": "^2.0.0",
-                "hast-util-parse-selector": "^3.0.0",
-                "property-information": "^6.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0"
             },
             "funding": {
@@ -2259,152 +2594,50 @@
             "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ=="
         },
         "node_modules/html-void-elements": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
-            "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+            "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/human-signals": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
-            "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
-            "engines": {
-                "node": ">=12.20.0"
-            }
+        "node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+            "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+            "license": "BSD-2-Clause"
         },
-        "node_modules/ieee754": {
+        "node_modules/iron-webcrypto": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/import-meta-resolve": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
-            "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA==",
+            "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+            "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+            "license": "MIT",
             "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "node_modules/is-binary-path": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dependencies": {
-                "binary-extensions": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-buffer": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/is-core-module": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-            "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
-            "dependencies": {
-                "has": "^1.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "url": "https://github.com/sponsors/brc-dd"
             }
         },
         "node_modules/is-docker": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+            "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
+            "license": "MIT",
             "bin": {
                 "is-docker": "cli.js"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-fullwidth-code-point": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-inside-container": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
             "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "license": "MIT",
             "dependencies": {
                 "is-docker": "^3.0.0"
             },
@@ -2418,40 +2651,14 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-interactive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-            "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "engines": {
-                "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-plain-obj": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-stream": {
+        "node_modules/is-inside-container/node_modules/is-docker": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
@@ -2459,10 +2666,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-unicode-supported": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-            "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+        "node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -2471,44 +2679,25 @@
             }
         },
         "node_modules/is-wsl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "license": "MIT",
             "dependencies": {
-                "is-docker": "^2.0.0"
+                "is-inside-container": "^1.0.0"
             },
             "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-wsl/node_modules/is-docker": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-            "bin": {
-                "is-docker": "cli.js"
-            },
-            "engines": {
-                "node": ">=8"
+                "node": ">=16"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/isexe": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-        },
-        "node_modules/js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-        },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -2516,176 +2705,70 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsesc": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-            "bin": {
-                "jsesc": "bin/jsesc"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/jsonc-parser": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
-            "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
-        },
-        "node_modules/kind-of": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/kleur": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-            "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/load-yaml-file": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/load-yaml-file/-/load-yaml-file-0.2.0.tgz",
-            "integrity": "sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==",
-            "dependencies": {
-                "graceful-fs": "^4.1.5",
-                "js-yaml": "^3.13.0",
-                "pify": "^4.0.1",
-                "strip-bom": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/load-yaml-file/node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "node_modules/load-yaml-file/node_modules/js-yaml": {
-            "version": "3.14.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/load-yaml-file/node_modules/strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/locate-path": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-            "dependencies": {
-                "p-locate": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-symbols": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-            "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
-            "dependencies": {
-                "chalk": "^5.0.0",
-                "is-unicode-supported": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/log-symbols/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+            "license": "MIT"
         },
         "node_modules/longest-streak": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
             "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dependencies": {
-                "yallist": "^3.0.2"
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.2",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.2.tgz",
-            "integrity": "sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==",
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "license": "MIT",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.4.15"
-            },
-            "engines": {
-                "node": ">=12"
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+            "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.3",
+                "@babel/types": "^7.29.0",
+                "source-map-js": "^1.2.1"
             }
         },
         "node_modules/markdown-table": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
-            "integrity": "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/mdast-util-definitions": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.2.tgz",
-            "integrity": "sha512-8SVPMuHqlPME/z3gqVwWY4zVXn8lqKv/pAhC57FuJ40ImXyBpmO5ukh98zB2v7Blql2FiHjHv9LVztSIqjY+MA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+            "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "@types/unist": "^2.0.0",
-                "unist-util-visit": "^4.0.0"
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "unist-util-visit": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2693,48 +2776,39 @@
             }
         },
         "node_modules/mdast-util-find-and-replace": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
-            "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+            "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
                 "escape-string-regexp": "^5.0.0",
-                "unist-util-is": "^5.0.0",
-                "unist-util-visit-parents": "^5.0.0"
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/mdast-util-from-markdown": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
-            "integrity": "sha512-4xTO/M8c82qBcnQc1tgpNtubGUW/Y1tBQ1B0i5CtSoelOLKFYlElIr3bvgREYYO5iRqbMY1YuqZng0GVOI8Qww==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+            "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "@types/unist": "^2.0.0",
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
                 "decode-named-character-reference": "^1.0.0",
-                "mdast-util-to-string": "^3.1.0",
-                "micromark": "^3.0.0",
-                "micromark-util-decode-numeric-character-reference": "^1.0.0",
-                "micromark-util-decode-string": "^1.0.0",
-                "micromark-util-normalize-identifier": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0",
-                "unist-util-stringify-position": "^3.0.0",
-                "uvu": "^0.5.0"
+                "devlop": "^1.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unist-util-stringify-position": "^4.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2742,17 +2816,18 @@
             }
         },
         "node_modules/mdast-util-gfm": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
-            "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+            "license": "MIT",
             "dependencies": {
-                "mdast-util-from-markdown": "^1.0.0",
-                "mdast-util-gfm-autolink-literal": "^1.0.0",
-                "mdast-util-gfm-footnote": "^1.0.0",
-                "mdast-util-gfm-strikethrough": "^1.0.0",
-                "mdast-util-gfm-table": "^1.0.0",
-                "mdast-util-gfm-task-list-item": "^1.0.0",
-                "mdast-util-to-markdown": "^1.0.0"
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-gfm-autolink-literal": "^2.0.0",
+                "mdast-util-gfm-footnote": "^2.0.0",
+                "mdast-util-gfm-strikethrough": "^2.0.0",
+                "mdast-util-gfm-table": "^2.0.0",
+                "mdast-util-gfm-task-list-item": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2760,14 +2835,16 @@
             }
         },
         "node_modules/mdast-util-gfm-autolink-literal": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
-            "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+            "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
                 "ccount": "^2.0.0",
-                "mdast-util-find-and-replace": "^2.0.0",
-                "micromark-util-character": "^1.0.0"
+                "devlop": "^1.0.0",
+                "mdast-util-find-and-replace": "^3.0.0",
+                "micromark-util-character": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2775,13 +2852,16 @@
             }
         },
         "node_modules/mdast-util-gfm-footnote": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
-            "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "mdast-util-to-markdown": "^1.3.0",
-                "micromark-util-normalize-identifier": "^1.0.0"
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.1.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2789,12 +2869,14 @@
             }
         },
         "node_modules/mdast-util-gfm-strikethrough": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
-            "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+            "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "mdast-util-to-markdown": "^1.3.0"
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2802,14 +2884,16 @@
             }
         },
         "node_modules/mdast-util-gfm-table": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
-            "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+            "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
                 "markdown-table": "^3.0.0",
-                "mdast-util-from-markdown": "^1.0.0",
-                "mdast-util-to-markdown": "^1.3.0"
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2817,12 +2901,15 @@
             }
         },
         "node_modules/mdast-util-gfm-task-list-item": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
-            "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+            "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "mdast-util-to-markdown": "^1.3.0"
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2830,12 +2917,13 @@
             }
         },
         "node_modules/mdast-util-phrasing": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
-            "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+            "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "unist-util-is": "^5.0.0"
+                "@types/mdast": "^4.0.0",
+                "unist-util-is": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2843,18 +2931,20 @@
             }
         },
         "node_modules/mdast-util-to-hast": {
-            "version": "12.3.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
-            "integrity": "sha512-pits93r8PhnIoU4Vy9bjW39M2jJ6/tdHyja9rrot9uujkN7UTU9SDnE6WNJz/IGyQk3XHX6yNNtrBH6cQzm8Hw==",
+            "version": "13.2.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+            "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "@types/mdast": "^3.0.0",
-                "mdast-util-definitions": "^5.0.0",
-                "micromark-util-sanitize-uri": "^1.1.0",
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
                 "trim-lines": "^3.0.0",
-                "unist-util-generated": "^2.0.0",
-                "unist-util-position": "^4.0.0",
-                "unist-util-visit": "^4.0.0"
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2862,17 +2952,19 @@
             }
         },
         "node_modules/mdast-util-to-markdown": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
-            "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+            "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "@types/unist": "^2.0.0",
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
                 "longest-streak": "^3.0.0",
-                "mdast-util-phrasing": "^3.0.0",
-                "mdast-util-to-string": "^3.0.0",
-                "micromark-util-decode-string": "^1.0.0",
-                "unist-util-visit": "^4.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "unist-util-visit": "^5.0.0",
                 "zwitch": "^2.0.0"
             },
             "funding": {
@@ -2881,34 +2973,28 @@
             }
         },
         "node_modules/mdast-util-to-string": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.2.0.tgz",
-            "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+            "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0"
+                "@types/mdast": "^4.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/merge-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-        },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "engines": {
-                "node": ">= 8"
-            }
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "license": "CC0-1.0"
         },
         "node_modules/micromark": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.2.0.tgz",
-            "integrity": "sha512-uD66tJj54JLYq0De10AhWycZWGQNUvDI55xPgk2sQM5kn1JYlhbCMTtEeT27+vAhW2FBQxLlOmS3pmA7/2z4aA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+            "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -2919,30 +3005,31 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "@types/debug": "^4.0.0",
                 "debug": "^4.0.0",
                 "decode-named-character-reference": "^1.0.0",
-                "micromark-core-commonmark": "^1.0.1",
-                "micromark-factory-space": "^1.0.0",
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-chunked": "^1.0.0",
-                "micromark-util-combine-extensions": "^1.0.0",
-                "micromark-util-decode-numeric-character-reference": "^1.0.0",
-                "micromark-util-encode": "^1.0.0",
-                "micromark-util-normalize-identifier": "^1.0.0",
-                "micromark-util-resolve-all": "^1.0.0",
-                "micromark-util-sanitize-uri": "^1.0.0",
-                "micromark-util-subtokenize": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.1",
-                "uvu": "^0.5.0"
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-core-commonmark": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.1.0.tgz",
-            "integrity": "sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+            "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -2953,38 +3040,40 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "decode-named-character-reference": "^1.0.0",
-                "micromark-factory-destination": "^1.0.0",
-                "micromark-factory-label": "^1.0.0",
-                "micromark-factory-space": "^1.0.0",
-                "micromark-factory-title": "^1.0.0",
-                "micromark-factory-whitespace": "^1.0.0",
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-chunked": "^1.0.0",
-                "micromark-util-classify-character": "^1.0.0",
-                "micromark-util-html-tag-name": "^1.0.0",
-                "micromark-util-normalize-identifier": "^1.0.0",
-                "micromark-util-resolve-all": "^1.0.0",
-                "micromark-util-subtokenize": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.1",
-                "uvu": "^0.5.0"
+                "devlop": "^1.0.0",
+                "micromark-factory-destination": "^2.0.0",
+                "micromark-factory-label": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-title": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-html-tag-name": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-extension-gfm": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
-            "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+            "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+            "license": "MIT",
             "dependencies": {
-                "micromark-extension-gfm-autolink-literal": "^1.0.0",
-                "micromark-extension-gfm-footnote": "^1.0.0",
-                "micromark-extension-gfm-strikethrough": "^1.0.0",
-                "micromark-extension-gfm-table": "^1.0.0",
-                "micromark-extension-gfm-tagfilter": "^1.0.0",
-                "micromark-extension-gfm-task-list-item": "^1.0.0",
-                "micromark-util-combine-extensions": "^1.0.0",
-                "micromark-util-types": "^1.0.0"
+                "micromark-extension-gfm-autolink-literal": "^2.0.0",
+                "micromark-extension-gfm-footnote": "^2.0.0",
+                "micromark-extension-gfm-strikethrough": "^2.0.0",
+                "micromark-extension-gfm-table": "^2.0.0",
+                "micromark-extension-gfm-tagfilter": "^2.0.0",
+                "micromark-extension-gfm-task-list-item": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2992,14 +3081,15 @@
             }
         },
         "node_modules/micromark-extension-gfm-autolink-literal": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
-            "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+            "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-sanitize-uri": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0"
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3007,18 +3097,19 @@
             }
         },
         "node_modules/micromark-extension-gfm-footnote": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
-            "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+            "license": "MIT",
             "dependencies": {
-                "micromark-core-commonmark": "^1.0.0",
-                "micromark-factory-space": "^1.0.0",
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-normalize-identifier": "^1.0.0",
-                "micromark-util-sanitize-uri": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0",
-                "uvu": "^0.5.0"
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3026,16 +3117,17 @@
             }
         },
         "node_modules/micromark-extension-gfm-strikethrough": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
-            "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+            "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-chunked": "^1.0.0",
-                "micromark-util-classify-character": "^1.0.0",
-                "micromark-util-resolve-all": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0",
-                "uvu": "^0.5.0"
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3043,15 +3135,16 @@
             }
         },
         "node_modules/micromark-extension-gfm-table": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
-            "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+            "license": "MIT",
             "dependencies": {
-                "micromark-factory-space": "^1.0.0",
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0",
-                "uvu": "^0.5.0"
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3059,11 +3152,12 @@
             }
         },
         "node_modules/micromark-extension-gfm-tagfilter": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
-            "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+            "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-types": "^1.0.0"
+                "micromark-util-types": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3071,15 +3165,16 @@
             }
         },
         "node_modules/micromark-extension-gfm-task-list-item": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
-            "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+            "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+            "license": "MIT",
             "dependencies": {
-                "micromark-factory-space": "^1.0.0",
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0",
-                "uvu": "^0.5.0"
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3087,9 +3182,9 @@
             }
         },
         "node_modules/micromark-factory-destination": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.1.0.tgz",
-            "integrity": "sha512-XaNDROBgx9SgSChd69pjiGKbV+nfHGDPVYFs5dOoDd7ZnMAE+Cuu91BCpsY8RT2NP9vo/B8pds2VQNCLiu0zhg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+            "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3100,16 +3195,17 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0"
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-factory-label": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.1.0.tgz",
-            "integrity": "sha512-OLtyez4vZo/1NjxGhcpDSbHQ+m0IIGnT8BoPamh+7jVlzLJBH98zzuCoUeMxvM6WsNeh8wx8cKvqLiPHEACn0w==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+            "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3120,17 +3216,18 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0",
-                "uvu": "^0.5.0"
+                "devlop": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-factory-space": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.1.0.tgz",
-            "integrity": "sha512-cRzEj7c0OL4Mw2v6nwzttyOZe8XY/Z8G0rzmWQZTBi/jjwyw/U4uqKtUORXQrR5bAZZnbTI/feRV/R7hc4jQYQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3141,15 +3238,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-types": "^1.0.0"
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-factory-title": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.1.0.tgz",
-            "integrity": "sha512-J7n9R3vMmgjDOCY8NPw55jiyaQnH5kBdV2/UXCtZIpnHH3P6nHUKaH7XXEYuWwx/xUJcawa8plLBEjMPU24HzQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+            "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3160,17 +3258,18 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-factory-space": "^1.0.0",
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0"
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-factory-whitespace": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.1.0.tgz",
-            "integrity": "sha512-v2WlmiymVSp5oMg+1Q0N1Lxmt6pMhIHD457whWM7/GUlEks1hI9xj5w3zbc4uuMKXGisksZk8DzP2UyGbGqNsQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+            "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3181,17 +3280,18 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-factory-space": "^1.0.0",
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0"
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-util-character": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.2.0.tgz",
-            "integrity": "sha512-lXraTwcX3yH/vMDaFWCQJP1uIszLVebzUa3ZHdrgxr7KEU/9mL4mVgCpGbyhvNLNlauROiNUq7WN5u7ndbY6xg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3202,15 +3302,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0"
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-util-chunked": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.1.0.tgz",
-            "integrity": "sha512-Ye01HXpkZPNcV6FiyoW2fGZDUw4Yc7vT0E9Sad83+bEDiCJ1uXu0S3mr8WLpsz3HaG3x2q0HM6CTuPdcZcluFQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+            "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3221,14 +3322,15 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-symbol": "^1.0.0"
+                "micromark-util-symbol": "^2.0.0"
             }
         },
         "node_modules/micromark-util-classify-character": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.1.0.tgz",
-            "integrity": "sha512-SL0wLxtKSnklKSUplok1WQFoGhUdWYKggKUiqhX+Swala+BtptGCu5iPRc+xvzJ4PXE/hwM3FNXsfEVgoZsWbw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+            "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3239,16 +3341,17 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0"
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-util-combine-extensions": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.1.0.tgz",
-            "integrity": "sha512-Q20sp4mfNf9yEqDL50WwuWZHUrCO4fEyeDCnMGmG5Pr0Cz15Uo7KBs6jq+dq0EgX4DPwwrh9m0X+zPV1ypFvUA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+            "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3259,15 +3362,16 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-chunked": "^1.0.0",
-                "micromark-util-types": "^1.0.0"
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-util-decode-numeric-character-reference": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.1.0.tgz",
-            "integrity": "sha512-m9V0ExGv0jB1OT21mrWcuf4QhP46pH1KkfWy9ZEezqHKAxkj4mPCy3nIH1rkbdMlChLHX531eOrymlwyZIf2iw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+            "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3278,14 +3382,15 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-symbol": "^1.0.0"
+                "micromark-util-symbol": "^2.0.0"
             }
         },
         "node_modules/micromark-util-decode-string": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.1.0.tgz",
-            "integrity": "sha512-YphLGCK8gM1tG1bd54azwyrQRjCFcmgj2S2GoJDNnh4vYtnL38JS8M4gpxzOPNyHdNEpheyWXCTnnTDY3N+NVQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+            "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3296,47 +3401,18 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "decode-named-character-reference": "^1.0.0",
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-decode-numeric-character-reference": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0"
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
             }
         },
         "node_modules/micromark-util-encode": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.1.0.tgz",
-            "integrity": "sha512-EuEzTWSTAj9PA5GOAs992GzNh2dGQO52UvAbtSOMvXTxv3Criqb6IOzJUBCmEqrrXSblJIJBbFFv6zPxpreiJw==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ]
-        },
-        "node_modules/micromark-util-html-tag-name": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.2.0.tgz",
-            "integrity": "sha512-VTQzcuQgFUD7yYztuQFKXT49KghjtETQ+Wv/zUjGSGBioZnkA4P1XXZPT1FHeJA6RwRXSF47yvJ1tsJdoxwO+Q==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ]
-        },
-        "node_modules/micromark-util-normalize-identifier": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.1.0.tgz",
-            "integrity": "sha512-N+w5vhqrBihhjdpM8+5Xsxy71QWqGn7HYNUvch71iV2PM7+E3uWGox1Qp90loa1ephtCxG2ftRV/Conitc6P2Q==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+            "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3347,14 +3423,47 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-html-tag-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+            "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-normalize-identifier": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+            "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-symbol": "^1.0.0"
+                "micromark-util-symbol": "^2.0.0"
             }
         },
         "node_modules/micromark-util-resolve-all": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.1.0.tgz",
-            "integrity": "sha512-b/G6BTMSg+bX+xVCshPTPyAu2tmA0E4X98NSR7eIbeC6ycCqCeE7wjfDIgzEbkzdEVJXRtOG4FbEm/uGbCRouA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+            "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3365,14 +3474,15 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-types": "^1.0.0"
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-util-sanitize-uri": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.2.0.tgz",
-            "integrity": "sha512-QO4GXv0XZfWey4pYFndLUKEAktKkG5kZTdUNaTAkzbuJxn2tNBOr+QtxR2XpWaMhbImT2dPzyLrPXLlPhph34A==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+            "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3383,16 +3493,17 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-character": "^1.0.0",
-                "micromark-util-encode": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0"
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
             }
         },
         "node_modules/micromark-util-subtokenize": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.1.0.tgz",
-            "integrity": "sha512-kUQHyzRoxvZO2PuLzMt2P/dwVsTiivCK8icYTeR+3WgbuPqfHgPPy7nFKbeqRivBvn/3N3GBiNC+JRTMSxEC7A==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+            "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3403,17 +3514,18 @@
                     "url": "https://opencollective.com/unified"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "micromark-util-chunked": "^1.0.0",
-                "micromark-util-symbol": "^1.0.0",
-                "micromark-util-types": "^1.0.0",
-                "uvu": "^0.5.0"
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
             }
         },
         "node_modules/micromark-util-symbol": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.1.0.tgz",
-            "integrity": "sha512-uEjpEYY6KMs1g7QfJ2eX1SQEV+ZT4rUD3UcF6l57acZvLNK7PBZL+ty82Z1qhK1/yXIY4bdx04FKMgR0g4IAag==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3423,12 +3535,13 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/micromark-util-types": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.1.0.tgz",
-            "integrity": "sha512-ukRBgie8TIAcacscVHSiddHjO4k/q3pnedmzMQ4iwDcK0FtFCohKOlFbaOL/mPgfnPsL3C1ZyxJa4sbWrBl3jg==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+            "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -3438,65 +3551,35 @@
                     "type": "OpenCollective",
                     "url": "https://opencollective.com/unified"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
-        "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-            "dependencies": {
-                "braces": "^3.0.2",
-                "picomatch": "^2.3.1"
-            },
+        "node_modules/mrmime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+            "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+            "license": "MIT",
             "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/mime": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-            "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/mimic-fn": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/mri": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-            "engines": {
-                "node": ">=4"
+                "node": ">=10"
             }
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -3504,197 +3587,166 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
-        "node_modules/network-information-types": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/network-information-types/-/network-information-types-0.1.1.tgz",
-            "integrity": "sha512-mLXNafJYOkiJB6IlF727YWssTRpXitR+tKSLyA5VAdBi3SOvLf5gtizHgxf241YHPWocnAO/fAhVrB/68tPHDw==",
-            "peerDependencies": {
-                "typescript": ">= 3.0.0"
+        "node_modules/neotraverse": {
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+            "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/nlcst-to-string": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-3.1.1.tgz",
-            "integrity": "sha512-63mVyqaqt0cmn2VcI2aH6kxe1rLAmSROqHMA0i4qqg1tidkfExgpb0FGMikMCn86mw5dFtBtEANfmSSK7TjNHw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+            "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/nlcst": "^1.0.0"
+                "@types/nlcst": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/node-releases": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+        "node_modules/node-fetch-native": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+            "license": "MIT"
+        },
+        "node_modules/node-mock-http": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+            "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+            "license": "MIT"
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/npm-run-path": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
-            "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+        "node_modules/nth-check": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "path-key": "^4.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "boolbase": "^1.0.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
-        "node_modules/npm-run-path/node_modules/path-key": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
         },
-        "node_modules/onetime": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+        "node_modules/ofetch": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+            "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+            "license": "MIT",
             "dependencies": {
-                "mimic-fn": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "destr": "^2.0.5",
+                "node-fetch-native": "^1.6.7",
+                "ufo": "^1.6.1"
             }
         },
-        "node_modules/open": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
-            "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+        "node_modules/ohash": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+            "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+            "license": "MIT"
+        },
+        "node_modules/oniguruma-parser": {
+            "version": "0.12.2",
+            "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+            "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+            "license": "MIT"
+        },
+        "node_modules/oniguruma-to-es": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+            "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+            "license": "MIT",
             "dependencies": {
-                "default-browser": "^4.0.0",
-                "define-lazy-prop": "^3.0.0",
-                "is-inside-container": "^1.0.0",
-                "is-wsl": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ora": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
-            "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
-            "dependencies": {
-                "chalk": "^5.0.0",
-                "cli-cursor": "^4.0.0",
-                "cli-spinners": "^2.6.1",
-                "is-interactive": "^2.0.0",
-                "is-unicode-supported": "^1.1.0",
-                "log-symbols": "^5.1.0",
-                "stdin-discarder": "^0.1.0",
-                "strip-ansi": "^7.0.1",
-                "wcwidth": "^1.0.1"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/ora/node_modules/chalk": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-            "engines": {
-                "node": "^12.17.0 || ^14.13 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
+                "oniguruma-parser": "^0.12.2",
+                "regex": "^6.1.0",
+                "regex-recursion": "^6.0.2"
             }
         },
         "node_modules/p-limit": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-            "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+            "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+            "license": "MIT",
             "dependencies": {
-                "yocto-queue": "^1.0.0"
+                "yocto-queue": "^1.2.1"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-locate": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+        "node_modules/p-queue": {
+            "version": "9.3.0",
+            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+            "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+            "license": "MIT",
             "dependencies": {
-                "p-limit": "^3.0.2"
+                "eventemitter3": "^5.0.4",
+                "p-timeout": "^7.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-locate/node_modules/p-limit": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-            "dependencies": {
-                "yocto-queue": "^0.1.0"
-            },
+        "node_modules/p-timeout": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+            "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+            "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-locate/node_modules/yocto-queue": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-try": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "engines": {
-                "node": ">=6"
-            }
+        "node_modules/package-manager-detector": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+            "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+            "license": "MIT"
         },
         "node_modules/parse-latin": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-5.0.1.tgz",
-            "integrity": "sha512-b/K8ExXaWC9t34kKeDV8kGXBkXZ1HCSAZRYE7HR14eA1GlXX5L8iWhs8USJNhQU9q5ci413jCKF0gOyovvyRBg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+            "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+            "license": "MIT",
             "dependencies": {
-                "nlcst-to-string": "^3.0.0",
-                "unist-util-modify-children": "^3.0.0",
-                "unist-util-visit-children": "^2.0.0"
+                "@types/nlcst": "^2.0.0",
+                "@types/unist": "^3.0.0",
+                "nlcst-to-string": "^4.0.0",
+                "unist-util-modify-children": "^4.0.0",
+                "unist-util-visit-children": "^3.0.0",
+                "vfile": "^6.0.0"
             },
             "funding": {
                 "type": "github",
@@ -3702,123 +3754,45 @@
             }
         },
         "node_modules/parse5": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-            "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-        },
-        "node_modules/path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "engines": {
-                "node": ">=8"
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
             }
         },
-        "node_modules/path-key": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/path-parse": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-        },
-        "node_modules/path-to-regexp": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
-            "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
+        "node_modules/piccolore": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
+            "integrity": "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==",
+            "license": "ISC"
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/pify": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/pkg-dir": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-            "dependencies": {
-                "find-up": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pkg-dir/node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/postcss": {
-            "version": "8.4.28",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-            "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+            "version": "8.5.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -3833,147 +3807,88 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "nanoid": "^3.3.12",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
             }
         },
-        "node_modules/preferred-pm": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.0.3.tgz",
-            "integrity": "sha512-+wZgbxNES/KlJs9q40F/1sfOd/j7f1O9JaHcW5Dsn3aUUOZg3L2bjpVUcKV2jvtElYfoTuQiNeMfQJ4kwUAhCQ==",
-            "dependencies": {
-                "find-up": "^5.0.0",
-                "find-yarn-workspace-root2": "1.2.16",
-                "path-exists": "^4.0.0",
-                "which-pm": "2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/prettier": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
-        },
-        "node_modules/prettier-plugin-astro": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.9.1.tgz",
-            "integrity": "sha512-pYZXSbdq0eElvzoIMArzv1SBn1NUXzopjlcnt6Ql8VW32PjC12NovwBjXJ6rh8qQLi7vF8jNqAbraKW03UPfag==",
-            "dependencies": {
-                "@astrojs/compiler": "^1.0.1",
-                "prettier": "^2.8.3",
-                "sass-formatter": "^0.7.5",
-                "synckit": "^0.8.4"
-            },
-            "engines": {
-                "node": "^14.15.0 || >=16.0.0",
-                "pnpm": ">=7.14.0"
-            }
-        },
         "node_modules/prismjs": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-            "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/prompts": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-            "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-            "dependencies": {
-                "kleur": "^3.0.3",
-                "sisteransi": "^1.0.5"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/prompts/node_modules/kleur": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-            "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/property-information": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.2.0.tgz",
-            "integrity": "sha512-kma4U7AFCTwpqq5twzC1YVIDXSqg6qQK6JN0smOw8fgRy1OkMi0CYSzFmsy6dnqSenamAtj0CyXMUJ1Mf6oROg==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+            "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/readable-stream": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
+        "node_modules/radix3": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+            "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+            "license": "MIT"
         },
         "node_modules/readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+            "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+            "license": "MIT",
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">= 20.19.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/rehype": {
-            "version": "12.0.1",
-            "resolved": "https://registry.npmjs.org/rehype/-/rehype-12.0.1.tgz",
-            "integrity": "sha512-ey6kAqwLM3X6QnMDILJthGvG1m1ULROS9NT4uG9IDCuv08SFyLlreSuvOa//DgEvbXx62DS6elGVqusWhRUbgw==",
+        "node_modules/regex": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+            "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "rehype-parse": "^8.0.0",
-                "rehype-stringify": "^9.0.0",
-                "unified": "^10.0.0"
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-recursion": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+            "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+            "license": "MIT",
+            "dependencies": {
+                "regex-utilities": "^2.3.0"
+            }
+        },
+        "node_modules/regex-utilities": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+            "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+            "license": "MIT"
+        },
+        "node_modules/rehype": {
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/rehype/-/rehype-13.0.2.tgz",
+            "integrity": "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "rehype-parse": "^9.0.0",
+                "rehype-stringify": "^10.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3981,14 +3896,14 @@
             }
         },
         "node_modules/rehype-parse": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-8.0.4.tgz",
-            "integrity": "sha512-MJJKONunHjoTh4kc3dsM1v3C9kGrrxvA3U8PxZlP2SjH8RNUSrb+lF7Y0KVaUDnGH2QZ5vAn7ulkiajM9ifuqg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
+            "integrity": "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "hast-util-from-parse5": "^7.0.0",
-                "parse5": "^6.0.0",
-                "unified": "^10.0.0"
+                "@types/hast": "^3.0.0",
+                "hast-util-from-html": "^2.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3996,13 +3911,14 @@
             }
         },
         "node_modules/rehype-raw": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-6.1.1.tgz",
-            "integrity": "sha512-d6AKtisSRtDRX4aSPsJGTfnzrX2ZkHQLE5kiUuGOeEoLpbEulFF4hj0mLPbsa+7vmguDKOVVEQdHKDSwoaIDsQ==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+            "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "hast-util-raw": "^7.2.0",
-                "unified": "^10.0.0"
+                "@types/hast": "^3.0.0",
+                "hast-util-raw": "^9.0.0",
+                "vfile": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4010,13 +3926,14 @@
             }
         },
         "node_modules/rehype-stringify": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz",
-            "integrity": "sha512-kWiZ1bgyWlgOxpqD5HnxShKAdXtb2IUljn3hQAhySeak6IOQPPt6DeGnsIh4ixm7yKJWzm8TXFuC/lPfcWHJqw==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+            "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "hast-util-to-html": "^8.0.0",
-                "unified": "^10.0.0"
+                "@types/hast": "^3.0.0",
+                "hast-util-to-html": "^9.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4024,14 +3941,17 @@
             }
         },
         "node_modules/remark-gfm": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
-            "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+            "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "mdast-util-gfm": "^2.0.0",
-                "micromark-extension-gfm": "^2.0.0",
-                "unified": "^10.0.0"
+                "@types/mdast": "^4.0.0",
+                "mdast-util-gfm": "^3.0.0",
+                "micromark-extension-gfm": "^3.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-stringify": "^11.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4039,13 +3959,15 @@
             }
         },
         "node_modules/remark-parse": {
-            "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
-            "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+            "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/mdast": "^3.0.0",
-                "mdast-util-from-markdown": "^1.0.0",
-                "unified": "^10.0.0"
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4053,14 +3975,16 @@
             }
         },
         "node_modules/remark-rehype": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
-            "integrity": "sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==",
+            "version": "11.1.2",
+            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+            "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+            "license": "MIT",
             "dependencies": {
-                "@types/hast": "^2.0.0",
-                "@types/mdast": "^3.0.0",
-                "mdast-util-to-hast": "^12.1.0",
-                "unified": "^10.0.0"
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "unified": "^11.0.0",
+                "vfile": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4068,80 +3992,54 @@
             }
         },
         "node_modules/remark-smartypants": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-2.0.0.tgz",
-            "integrity": "sha512-Rc0VDmr/yhnMQIz8n2ACYXlfw/P/XZev884QU1I5u+5DgJls32o97Vc1RbK3pfumLsJomS2yy8eT4Fxj/2MDVA==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
+            "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+            "license": "MIT",
             "dependencies": {
-                "retext": "^8.1.0",
-                "retext-smartypants": "^5.1.0",
-                "unist-util-visit": "^4.1.0"
+                "retext": "^9.0.0",
+                "retext-smartypants": "^6.0.0",
+                "unified": "^11.0.4",
+                "unist-util-visit": "^5.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=16.0.0"
             }
         },
-        "node_modules/resolve": {
-            "version": "1.22.4",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-            "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+        "node_modules/remark-stringify": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+            "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+            "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.13.0",
-                "path-parse": "^1.0.7",
-                "supports-preserve-symlinks-flag": "^1.0.0"
-            },
-            "bin": {
-                "resolve": "bin/resolve"
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/restore-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-            "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "license": "MIT",
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/restore-cursor/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/restore-cursor/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
         },
         "node_modules/retext": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/retext/-/retext-8.1.0.tgz",
-            "integrity": "sha512-N9/Kq7YTn6ZpzfiGW45WfEGJqFf1IM1q8OsRa1CGzIebCJBNCANDRmOrholiDRGKo/We7ofKR4SEvcGAWEMD3Q==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+            "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/nlcst": "^1.0.0",
-                "retext-latin": "^3.0.0",
-                "retext-stringify": "^3.0.0",
-                "unified": "^10.0.0"
+                "@types/nlcst": "^2.0.0",
+                "retext-latin": "^4.0.0",
+                "retext-stringify": "^4.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4149,14 +4047,14 @@
             }
         },
         "node_modules/retext-latin": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-3.1.0.tgz",
-            "integrity": "sha512-5MrD1tuebzO8ppsja5eEu+ZbBeUNCjoEarn70tkXOS7Bdsdf6tNahsv2bY0Z8VooFF6cw7/6S+d3yI/TMlMVVQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+            "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/nlcst": "^1.0.0",
-                "parse-latin": "^5.0.0",
-                "unherit": "^3.0.0",
-                "unified": "^10.0.0"
+                "@types/nlcst": "^2.0.0",
+                "parse-latin": "^7.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4164,14 +4062,14 @@
             }
         },
         "node_modules/retext-smartypants": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-5.2.0.tgz",
-            "integrity": "sha512-Do8oM+SsjrbzT2UNIKgheP0hgUQTDDQYyZaIY3kfq0pdFzoPk+ZClYJ+OERNXveog4xf1pZL4PfRxNoVL7a/jw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+            "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/nlcst": "^1.0.0",
-                "nlcst-to-string": "^3.0.0",
-                "unified": "^10.0.0",
-                "unist-util-visit": "^4.0.0"
+                "@types/nlcst": "^2.0.0",
+                "nlcst-to-string": "^4.0.0",
+                "unist-util-visit": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4179,223 +4077,84 @@
             }
         },
         "node_modules/retext-stringify": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-3.1.0.tgz",
-            "integrity": "sha512-767TLOaoXFXyOnjx/EggXlb37ZD2u4P1n0GJqVdpipqACsQP+20W+BNpMYrlJkq7hxffnFk+jc6mAK9qrbuB8w==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+            "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/nlcst": "^1.0.0",
-                "nlcst-to-string": "^3.0.0",
-                "unified": "^10.0.0"
+                "@types/nlcst": "^2.0.0",
+                "nlcst-to-string": "^4.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/rollup": {
-            "version": "3.28.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
-            "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+            "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "1.0.8"
+            },
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=14.18.0",
+                "node": ">=18.0.0",
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
+                "@rollup/rollup-android-arm-eabi": "4.60.4",
+                "@rollup/rollup-android-arm64": "4.60.4",
+                "@rollup/rollup-darwin-arm64": "4.60.4",
+                "@rollup/rollup-darwin-x64": "4.60.4",
+                "@rollup/rollup-freebsd-arm64": "4.60.4",
+                "@rollup/rollup-freebsd-x64": "4.60.4",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+                "@rollup/rollup-linux-arm64-musl": "4.60.4",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+                "@rollup/rollup-linux-loong64-musl": "4.60.4",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+                "@rollup/rollup-linux-x64-gnu": "4.60.4",
+                "@rollup/rollup-linux-x64-musl": "4.60.4",
+                "@rollup/rollup-openbsd-x64": "4.60.4",
+                "@rollup/rollup-openharmony-arm64": "4.60.4",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+                "@rollup/rollup-win32-x64-gnu": "4.60.4",
+                "@rollup/rollup-win32-x64-msvc": "4.60.4",
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/run-applescript": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
-            "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
-            "dependencies": {
-                "execa": "^5.0.0"
-            },
+        "node_modules/rollup/node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "license": "MIT"
+        },
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/run-applescript/node_modules/execa": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-            "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/run-applescript/node_modules/human-signals": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-            "engines": {
-                "node": ">=10.17.0"
-            }
-        },
-        "node_modules/run-applescript/node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/run-applescript/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/run-applescript/node_modules/npm-run-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-            "dependencies": {
-                "path-key": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/run-applescript/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dependencies": {
-                "mimic-fn": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/run-applescript/node_modules/strip-final-newline": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
-            }
-        },
-        "node_modules/s.color": {
-            "version": "0.0.15",
-            "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
-            "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA=="
-        },
-        "node_modules/sade": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
-            "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
-            "dependencies": {
-                "mri": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/sass-formatter": {
-            "version": "0.7.7",
-            "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.7.tgz",
-            "integrity": "sha512-axtQ7c7Cf4UgHsD8e4okhIkkc90+tdgBIfUMx69+qJuMNq9EOo2k+RH/mDKj0XeA5z3nC1Ca5TCntuxRhI+1MA==",
-            "dependencies": {
-                "suf-log": "^2.5.3"
-            }
-        },
-        "node_modules/section-matter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-            "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-            "dependencies": {
-                "extend-shallow": "^2.0.1",
-                "kind-of": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=4"
+                "node": ">=11.0.0"
             }
         },
         "node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -4403,76 +4162,93 @@
                 "node": ">=10"
             }
         },
-        "node_modules/semver/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+        "node_modules/sharp": {
+            "version": "0.34.5",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+            "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "optional": true,
             "dependencies": {
-                "yallist": "^4.0.0"
+                "@img/colour": "^1.0.0",
+                "detect-libc": "^2.1.2",
+                "semver": "^7.7.3"
             },
             "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/semver/node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-        },
-        "node_modules/server-destroy": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-            "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ=="
-        },
-        "node_modules/shebang-command": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dependencies": {
-                "shebang-regex": "^3.0.0"
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
             },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/shebang-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "engines": {
-                "node": ">=8"
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.34.5",
+                "@img/sharp-darwin-x64": "0.34.5",
+                "@img/sharp-libvips-darwin-arm64": "1.2.4",
+                "@img/sharp-libvips-darwin-x64": "1.2.4",
+                "@img/sharp-libvips-linux-arm": "1.2.4",
+                "@img/sharp-libvips-linux-arm64": "1.2.4",
+                "@img/sharp-libvips-linux-ppc64": "1.2.4",
+                "@img/sharp-libvips-linux-riscv64": "1.2.4",
+                "@img/sharp-libvips-linux-s390x": "1.2.4",
+                "@img/sharp-libvips-linux-x64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+                "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+                "@img/sharp-linux-arm": "0.34.5",
+                "@img/sharp-linux-arm64": "0.34.5",
+                "@img/sharp-linux-ppc64": "0.34.5",
+                "@img/sharp-linux-riscv64": "0.34.5",
+                "@img/sharp-linux-s390x": "0.34.5",
+                "@img/sharp-linux-x64": "0.34.5",
+                "@img/sharp-linuxmusl-arm64": "0.34.5",
+                "@img/sharp-linuxmusl-x64": "0.34.5",
+                "@img/sharp-wasm32": "0.34.5",
+                "@img/sharp-win32-arm64": "0.34.5",
+                "@img/sharp-win32-ia32": "0.34.5",
+                "@img/sharp-win32-x64": "0.34.5"
             }
         },
         "node_modules/shiki": {
-            "version": "0.14.3",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.3.tgz",
-            "integrity": "sha512-U3S/a+b0KS+UkTyMjoNojvTgrBHjgp7L6ovhFVZsXmBGnVdQ4K4U9oK0z63w538S91ATngv1vXigHCSWOwnr+g==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.1.0.tgz",
+            "integrity": "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==",
+            "license": "MIT",
             "dependencies": {
-                "ansi-sequence-parser": "^1.1.0",
-                "jsonc-parser": "^3.2.0",
-                "vscode-oniguruma": "^1.7.0",
-                "vscode-textmate": "^8.0.0"
+                "@shikijs/core": "4.1.0",
+                "@shikijs/engine-javascript": "4.1.0",
+                "@shikijs/engine-oniguruma": "4.1.0",
+                "@shikijs/langs": "4.1.0",
+                "@shikijs/themes": "4.1.0",
+                "@shikijs/types": "4.1.0",
+                "@shikijs/vscode-textmate": "^10.0.2",
+                "@types/hast": "^3.0.4"
+            },
+            "engines": {
+                "node": ">=20"
             }
-        },
-        "node_modules/shiki/node_modules/jsonc-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
-        },
-        "node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
         },
         "node_modules/sisteransi": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+            "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+            "license": "MIT"
+        },
+        "node_modules/smol-toml": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+            "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">= 18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/cyyynthia"
+            }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4481,66 +4257,17 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
             "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
-        },
-        "node_modules/stdin-discarder": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-            "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
-            "dependencies": {
-                "bl": "^5.0.0"
-            },
-            "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/streamsearch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-            "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
-        "node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/stringify-entities": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.3.tgz",
-            "integrity": "sha512-BP9nNHMhhfcMbiuQKCqMjhDP5yBCAxsPu4pHFFzJ6Alo9dZgY4VLDPutXqIjpRiMoKdp7Av85Gr73Q5uH9k7+g==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+            "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+            "license": "MIT",
             "dependencies": {
                 "character-entities-html4": "^2.0.0",
                 "character-entities-legacy": "^3.0.0"
@@ -4550,187 +4277,104 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/strip-ansi": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+        "node_modules/svgo": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
+            "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+            "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^6.0.1"
+                "commander": "^11.1.0",
+                "css-select": "^5.1.0",
+                "css-tree": "^3.0.1",
+                "css-what": "^6.1.0",
+                "csso": "^5.0.5",
+                "picocolors": "^1.1.1",
+                "sax": "^1.5.0"
+            },
+            "bin": {
+                "svgo": "bin/svgo.js"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=16"
             },
             "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+                "type": "opencollective",
+                "url": "https://opencollective.com/svgo"
             }
         },
-        "node_modules/strip-bom": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-            "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+        "node_modules/tiny-inflate": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+            "license": "MIT"
+        },
+        "node_modules/tinyclip": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.13.tgz",
+            "integrity": "sha512-8OqlXQ35euK9+e7L68u8UwcODxkHoIkjbGsgXuARKNyQ5G6xt8nw1YPeMbxMLgCPFkToU+UEK5j05t2t8edKpQ==",
+            "license": "MIT",
             "engines": {
-                "node": ">=8"
+                "node": "^16.14.0 || >= 17.3.0"
             }
         },
-        "node_modules/strip-bom-string": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-            "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+        "node_modules/tinyexec": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.3.tgz",
+            "integrity": "sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==",
+            "license": "MIT",
             "engines": {
-                "node": ">=0.10.0"
+                "node": ">=18"
             }
         },
-        "node_modules/strip-final-newline": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+        "node_modules/tinyglobby": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">=12.0.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/suf-log": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
-            "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
-            "dependencies": {
-                "s.color": "0.0.15"
-            }
-        },
-        "node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/supports-preserve-symlinks-flag": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/synckit": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
-            "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
-            "dependencies": {
-                "@pkgr/utils": "^2.3.1",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": "^14.18.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/unts"
-            }
-        },
-        "node_modules/titleize": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
-            "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/to-fast-properties": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
+                "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
         "node_modules/trim-lines": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
             "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/trough": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
-            "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+            "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/tsconfig-resolver": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/tsconfig-resolver/-/tsconfig-resolver-3.0.1.tgz",
-            "integrity": "sha512-ZHqlstlQF449v8glscGRXzL6l2dZvASPCdXJRWG4gHEZlUVx2Jtmr+a2zeVG4LCsKhDXKRj5R3h0C/98UcVAQg==",
-            "dependencies": {
-                "@types/json5": "^0.0.30",
-                "@types/resolve": "^1.17.0",
-                "json5": "^2.1.3",
-                "resolve": "^1.17.0",
-                "strip-bom": "^4.0.0",
-                "type-fest": "^0.13.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ifiokjr"
-            }
-        },
-        "node_modules/tsconfig-resolver/node_modules/type-fest": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/tslib": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-            "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
-        },
-        "node_modules/type-fest": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-            "engines": {
-                "node": ">=12.20"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4739,59 +4383,75 @@
                 "node": ">=14.17"
             }
         },
-        "node_modules/undici": {
-            "version": "5.23.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.23.0.tgz",
-            "integrity": "sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==",
-            "dependencies": {
-                "busboy": "^1.6.0"
-            },
-            "engines": {
-                "node": ">=14.0"
-            }
+        "node_modules/ufo": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+            "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+            "license": "MIT"
         },
-        "node_modules/unherit": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/unherit/-/unherit-3.0.1.tgz",
-            "integrity": "sha512-akOOQ/Yln8a2sgcLj4U0Jmx0R5jpIg2IUyRrWOzmEbjBtGzBdHtSeFKgoEcoH4KYIG/Pb8GQ/BwtYm0GCq1Sqg==",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
+        "node_modules/ultrahtml": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
+            "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
+            "license": "MIT"
+        },
+        "node_modules/uncrypto": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+            "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+            "license": "MIT"
         },
         "node_modules/unified": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
-            "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0",
+                "@types/unist": "^3.0.0",
                 "bail": "^2.0.0",
+                "devlop": "^1.0.0",
                 "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
                 "is-plain-obj": "^4.0.0",
                 "trough": "^2.0.0",
-                "vfile": "^5.0.0"
+                "vfile": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/unist-util-generated": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
-            "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
+        "node_modules/unifont": {
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
+            "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.1.0",
+                "ofetch": "^1.5.1",
+                "ohash": "^2.0.11"
+            }
+        },
+        "node_modules/unist-util-find-after": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+            "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/unist-util-is": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-            "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+            "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0"
+                "@types/unist": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4799,11 +4459,12 @@
             }
         },
         "node_modules/unist-util-modify-children": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-3.1.1.tgz",
-            "integrity": "sha512-yXi4Lm+TG5VG+qvokP6tpnk+r1EPwyYL04JWDxLvgvPV40jANh7nm3udk65OOWquvbMDe+PL9+LmkxDpTv/7BA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+            "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0",
+                "@types/unist": "^3.0.0",
                 "array-iterate": "^2.0.0"
             },
             "funding": {
@@ -4812,11 +4473,26 @@
             }
         },
         "node_modules/unist-util-position": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.4.tgz",
-            "integrity": "sha512-kUBE91efOWfIVBo8xzh/uZQ7p9ffYRtUbMRZBNFYwf0RK8koUMx6dGUfwylLOKmaT2cs4wSW96QoYUSXAyEtpg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+            "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0"
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-remove-position": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+            "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-visit": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4824,11 +4500,12 @@
             }
         },
         "node_modules/unist-util-stringify-position": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
-            "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+            "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0"
+                "@types/unist": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4836,13 +4513,14 @@
             }
         },
         "node_modules/unist-util-visit": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.2.tgz",
-            "integrity": "sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+            "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-is": "^5.0.0",
-                "unist-util-visit-parents": "^5.1.1"
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4850,11 +4528,12 @@
             }
         },
         "node_modules/unist-util-visit-children": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-2.0.2.tgz",
-            "integrity": "sha512-+LWpMFqyUwLGpsQxpumsQ9o9DG2VGLFrpz+rpVXYIEdPy57GSy5HioC0g3bg/8WP9oCLlapQtklOzQ8uLS496Q==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+            "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0"
+                "@types/unist": "^3.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4862,86 +4541,123 @@
             }
         },
         "node_modules/unist-util-visit-parents": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-            "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+            "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-is": "^5.0.0"
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/untildify": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/update-browserslist-db": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-            "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
+        "node_modules/unstorage": {
+            "version": "1.17.5",
+            "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+            "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+            "license": "MIT",
             "dependencies": {
-                "escalade": "^3.1.1",
-                "picocolors": "^1.0.0"
-            },
-            "bin": {
-                "update-browserslist-db": "cli.js"
+                "anymatch": "^3.1.3",
+                "chokidar": "^5.0.0",
+                "destr": "^2.0.5",
+                "h3": "^1.15.10",
+                "lru-cache": "^11.2.7",
+                "node-fetch-native": "^1.6.7",
+                "ofetch": "^1.5.1",
+                "ufo": "^1.6.3"
             },
             "peerDependencies": {
-                "browserslist": ">= 4.21.0"
-            }
-        },
-        "node_modules/util-deprecate": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
-        "node_modules/uvu": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
-            "integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
-            "dependencies": {
-                "dequal": "^2.0.0",
-                "diff": "^5.0.0",
-                "kleur": "^4.0.3",
-                "sade": "^1.7.3"
+                "@azure/app-configuration": "^1.8.0",
+                "@azure/cosmos": "^4.2.0",
+                "@azure/data-tables": "^13.3.0",
+                "@azure/identity": "^4.6.0",
+                "@azure/keyvault-secrets": "^4.9.0",
+                "@azure/storage-blob": "^12.26.0",
+                "@capacitor/preferences": "^6 || ^7 || ^8",
+                "@deno/kv": ">=0.9.0",
+                "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+                "@planetscale/database": "^1.19.0",
+                "@upstash/redis": "^1.34.3",
+                "@vercel/blob": ">=0.27.1",
+                "@vercel/functions": "^2.2.12 || ^3.0.0",
+                "@vercel/kv": "^1 || ^2 || ^3",
+                "aws4fetch": "^1.0.20",
+                "db0": ">=0.2.1",
+                "idb-keyval": "^6.2.1",
+                "ioredis": "^5.4.2",
+                "uploadthing": "^7.4.4"
             },
-            "bin": {
-                "uvu": "bin.js"
-            },
-            "engines": {
-                "node": ">=8"
+            "peerDependenciesMeta": {
+                "@azure/app-configuration": {
+                    "optional": true
+                },
+                "@azure/cosmos": {
+                    "optional": true
+                },
+                "@azure/data-tables": {
+                    "optional": true
+                },
+                "@azure/identity": {
+                    "optional": true
+                },
+                "@azure/keyvault-secrets": {
+                    "optional": true
+                },
+                "@azure/storage-blob": {
+                    "optional": true
+                },
+                "@capacitor/preferences": {
+                    "optional": true
+                },
+                "@deno/kv": {
+                    "optional": true
+                },
+                "@netlify/blobs": {
+                    "optional": true
+                },
+                "@planetscale/database": {
+                    "optional": true
+                },
+                "@upstash/redis": {
+                    "optional": true
+                },
+                "@vercel/blob": {
+                    "optional": true
+                },
+                "@vercel/functions": {
+                    "optional": true
+                },
+                "@vercel/kv": {
+                    "optional": true
+                },
+                "aws4fetch": {
+                    "optional": true
+                },
+                "db0": {
+                    "optional": true
+                },
+                "idb-keyval": {
+                    "optional": true
+                },
+                "ioredis": {
+                    "optional": true
+                },
+                "uploadthing": {
+                    "optional": true
+                }
             }
         },
         "node_modules/vfile": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
-            "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+            "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0",
-                "vfile-message": "^3.0.0"
+                "@types/unist": "^3.0.0",
+                "vfile-message": "^4.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4949,12 +4665,13 @@
             }
         },
         "node_modules/vfile-location": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-4.1.0.tgz",
-            "integrity": "sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+            "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0",
-                "vfile": "^5.0.0"
+                "@types/unist": "^3.0.0",
+                "vfile": "^6.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4962,12 +4679,13 @@
             }
         },
         "node_modules/vfile-message": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
-            "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+            "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+            "license": "MIT",
             "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-stringify-position": "^3.0.0"
+                "@types/unist": "^3.0.0",
+                "unist-util-stringify-position": "^4.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -4975,37 +4693,48 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.4.9",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-            "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+            "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+            "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.18.10",
-                "postcss": "^8.4.27",
-                "rollup": "^3.27.1"
+                "esbuild": "^0.27.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^14.18.0 || >=16.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
             },
             "optionalDependencies": {
-                "fsevents": "~2.3.2"
+                "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": ">= 14",
-                "less": "*",
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
                 "lightningcss": "^1.21.0",
-                "sass": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
             },
             "peerDependenciesMeta": {
                 "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
                     "optional": true
                 },
                 "less": {
@@ -5017,6 +4746,9 @@
                 "sass": {
                     "optional": true
                 },
+                "sass-embedded": {
+                    "optional": true
+                },
                 "stylus": {
                     "optional": true
                 },
@@ -5025,381 +4757,27 @@
                 },
                 "terser": {
                     "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
                 }
             }
         },
-        "node_modules/vite/node_modules/@esbuild/android-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-            "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/android-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-            "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/android-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-            "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-            "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-            "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-            "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-            "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/linux-arm": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-            "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-            "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-            "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-            "cpu": [
-                "ia32"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-            "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-            "cpu": [
-                "loong64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-            "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-            "cpu": [
-                "mips64el"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-            "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-            "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
-            "cpu": [
-                "riscv64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-            "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
-            "cpu": [
-                "s390x"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/linux-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-            "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-            "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-            "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-            "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
-            "cpu": [
-                "arm64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-            "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
-            "cpu": [
-                "ia32"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/@esbuild/win32-x64": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-            "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-            "cpu": [
-                "x64"
-            ],
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/vite/node_modules/esbuild": {
-            "version": "0.18.20",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-            "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-            "hasInstallScript": true,
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "optionalDependencies": {
-                "@esbuild/android-arm": "0.18.20",
-                "@esbuild/android-arm64": "0.18.20",
-                "@esbuild/android-x64": "0.18.20",
-                "@esbuild/darwin-arm64": "0.18.20",
-                "@esbuild/darwin-x64": "0.18.20",
-                "@esbuild/freebsd-arm64": "0.18.20",
-                "@esbuild/freebsd-x64": "0.18.20",
-                "@esbuild/linux-arm": "0.18.20",
-                "@esbuild/linux-arm64": "0.18.20",
-                "@esbuild/linux-ia32": "0.18.20",
-                "@esbuild/linux-loong64": "0.18.20",
-                "@esbuild/linux-mips64el": "0.18.20",
-                "@esbuild/linux-ppc64": "0.18.20",
-                "@esbuild/linux-riscv64": "0.18.20",
-                "@esbuild/linux-s390x": "0.18.20",
-                "@esbuild/linux-x64": "0.18.20",
-                "@esbuild/netbsd-x64": "0.18.20",
-                "@esbuild/openbsd-x64": "0.18.20",
-                "@esbuild/sunos-x64": "0.18.20",
-                "@esbuild/win32-arm64": "0.18.20",
-                "@esbuild/win32-ia32": "0.18.20",
-                "@esbuild/win32-x64": "0.18.20"
-            }
-        },
         "node_modules/vitefu": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.4.tgz",
-            "integrity": "sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+            "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+            "license": "MIT",
+            "workspaces": [
+                "tests/deps/*",
+                "tests/projects/*",
+                "tests/projects/workspace/packages/*"
+            ],
             "peerDependencies": {
-                "vite": "^3.0.0 || ^4.0.0"
+                "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "vite": {
@@ -5407,190 +4785,45 @@
                 }
             }
         },
-        "node_modules/vscode-css-languageservice": {
-            "version": "6.2.6",
-            "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.2.6.tgz",
-            "integrity": "sha512-SA2WkeOecIpUiEbZnjOsP/fI5CRITZEiQGSHXKiDQDwLApfKcnLhZwMtOBbIifSzESVcQa7b/shX/nbnF4NoCg==",
-            "dependencies": {
-                "@vscode/l10n": "^0.0.14",
-                "vscode-languageserver-textdocument": "^1.0.8",
-                "vscode-languageserver-types": "^3.17.3",
-                "vscode-uri": "^3.0.7"
-            }
-        },
-        "node_modules/vscode-html-languageservice": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.0.6.tgz",
-            "integrity": "sha512-gCixNg6fjPO7+kwSMBAVXcwDRHdjz1WOyNfI0n5Wx0J7dfHG8ggb3zD1FI8E2daTZrwS1cooOiSoc1Xxph4qRQ==",
-            "dependencies": {
-                "@vscode/l10n": "^0.0.14",
-                "vscode-languageserver-textdocument": "^1.0.8",
-                "vscode-languageserver-types": "^3.17.3",
-                "vscode-uri": "^3.0.7"
-            }
-        },
-        "node_modules/vscode-jsonrpc": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-            "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/vscode-languageserver": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.1.0.tgz",
-            "integrity": "sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==",
-            "dependencies": {
-                "vscode-languageserver-protocol": "3.17.3"
-            },
-            "bin": {
-                "installServerIntoExtension": "bin/installServerIntoExtension"
-            }
-        },
-        "node_modules/vscode-languageserver-protocol": {
-            "version": "3.17.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-            "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
-            "dependencies": {
-                "vscode-jsonrpc": "8.1.0",
-                "vscode-languageserver-types": "3.17.3"
-            }
-        },
-        "node_modules/vscode-languageserver-textdocument": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
-            "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
-        },
-        "node_modules/vscode-languageserver-types": {
-            "version": "3.17.3",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-            "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
-        },
-        "node_modules/vscode-oniguruma": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-            "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
-        },
-        "node_modules/vscode-textmate": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-            "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
-        },
-        "node_modules/vscode-uri": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
-            "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
-        },
-        "node_modules/wcwidth": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-            "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-            "dependencies": {
-                "defaults": "^1.0.3"
-            }
-        },
         "node_modules/web-namespaces": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
             "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dependencies": {
-                "isexe": "^2.0.0"
-            },
-            "bin": {
-                "node-which": "bin/node-which"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/which-pm": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-2.0.0.tgz",
-            "integrity": "sha512-Lhs9Pmyph0p5n5Z3mVnN0yWcbQYUAD7rbQUiMsQxOJ3T57k7RFe35SUwWMf7dsbDZks1uOmw4AecB/JMDj3v/w==",
-            "dependencies": {
-                "load-yaml-file": "^0.2.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8.15"
             }
         },
         "node_modules/which-pm-runs": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
             "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
-        "node_modules/widest-line": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
-            "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
-            "dependencies": {
-                "string-width": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-            "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+        "node_modules/xxhash-wasm": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+            "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+            "license": "MIT"
         },
         "node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+            "license": "ISC",
             "engines": {
-                "node": ">=12"
+                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/yocto-queue": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-            "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+            "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12.20"
             },
@@ -5599,9 +4832,10 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.22.1",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.1.tgz",
-            "integrity": "sha512-+qUhAMl414+Elh+fRNtpU+byrwjDFOS1N7NioLY+tSlcADTx4TkCUua/hxJvxwDXcV4397/nZ420jy4n4+3WUg==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -5610,6 +4844,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
             "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+            "license": "MIT",
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"

--- a/package.json
+++ b/package.json
@@ -8,12 +8,16 @@
         "start": "astro dev",
         "build": "astro build",
         "preview": "astro preview",
+        "check": "astro check",
+        "lint:md": "markdownlint 'src/**/*.md'",
         "astro": "astro"
     },
     "dependencies": {
         "astro": "^6.4.2"
     },
     "devDependencies": {
+        "@astrojs/check": "^0.9.9",
+        "markdownlint-cli": "^0.48.0",
         "typescript": "^5.8.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
         "astro": "astro"
     },
     "dependencies": {
-        "astro": "^2.10.9"
+        "astro": "^6.4.2"
+    },
+    "devDependencies": {
+        "typescript": "^5.8.3"
     }
 }

--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -1,6 +1,5 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import Card from "../components/Card.astro";
 ---
 
 <Layout title="Footer">

--- a/src/layouts/Page.astro
+++ b/src/layouts/Page.astro
@@ -1,7 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
 import Footer from "../layouts/Footer.astro";
-import Card from "../components/Card.astro";
 const { frontmatter } = Astro.props;
 ---
 


### PR DESCRIPTION
## Changes

- **Astro** updated from ^2.10.9 to ^6.4.2
- **TypeScript** added as devDependency (^5.8.3)
- **GitHub Actions**: 
  - `withastro/action` v3 → v6
  - `actions/deploy-pages` v4 → v5
- Cleaned up commented-out options in deploy workflow

## Verification

- Build succeeds (
> @example/basics@0.0.1 build
> astro build

10:32:13 [types] Generated 28ms
10:32:13 [build] output: "static"
10:32:13 [build] mode: "static"
10:32:13 [build] directory: /home/maxulysse/workspace/annotation-cache.github.io/dist/
10:32:13 [build] Collecting build info...
10:32:13 [build] ✓ Completed in 37ms.
10:32:13 [build] Building static entrypoints...
10:32:14 [vite] ✓ built in 1.07s
10:32:14 [vite] ✓ built in 8ms
10:32:14 [build] Rearranging server assets...

 generating static routes 
10:32:14   ├─ /snpeff_cache/index.html (+14ms) 
10:32:14   ├─ /vep_cache/index.html (+3ms) 
10:32:14   ├─ /index.html (+3ms) 
10:32:14 ✓ Completed in 37ms.

10:32:14 [build] ✓ Completed in 1.17s.
10:32:14 [build] 3 page(s) built in 1.21s
10:32:14 [build] Complete! generates all 3 pages without errors)
- No breaking changes affected this site's pages/components