### PR TITLE
fix: remove nested Layout wrapper from Footer.astro

### DIFF
--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -1,34 +1,28 @@
----
-import Layout from "../layouts/Layout.astro";
----
-
-<Layout title="Footer">
-    <p class="footer">
-        This resource was developed by <a href="https://maxulysse.github.io/"
-            >Maxime U. Garcia</a
-        >, bioinformatician at <a href="https://seqera.io/">Seqera</a> in Barcelona
-        | Stockholm. It is based on <a href="https://pcingola.github.io/SnpEff/"
-            >SnpEff</a
-        > and
-        <a href="https://www.ensembl.org/info/docs/tools/vep/index.html">VEP</a>
-        ressources. It was created for the <a href="https://nf-co.re/"
-            >nf-core</a
-        > community, and has been uploaded to S3 with the help of <a
-            href="https://www.nextflow.io/">Nextflow</a
-        > and <a href="https://cloud.seqera.io/">Seqera Platform</a>. All of that was
-        made possible by <a href="https://registry.opendata.aws/"
-            >Open Data on AWS</a
-        >.
-        <br />
-        <a href="https://registry.opendata.aws/"
-            ><img
-                title="Open Data on AWS"
-                src="/AWS_logo.png"
-                height="100"
-            /></a
-        >
-        <a href="https://nf-co.re/"
-            ><img title="nf-core" src="/nf-core_logo.png" height="100" /></a
-        >
-    </p>
-</Layout>
+<p class="footer">
+    This resource was developed by <a href="https://maxulysse.github.io/"
+        >Maxime U. Garcia</a
+    >, bioinformatician at <a href="https://seqera.io/">Seqera</a> in Barcelona
+    | Stockholm. It is based on <a href="https://pcingola.github.io/SnpEff/"
+        >SnpEff</a
+    > and
+    <a href="https://www.ensembl.org/info/docs/tools/vep/index.html">VEP</a>
+    ressources. It was created for the <a href="https://nf-co.re/"
+        >nf-core</a
+    > community, and has been uploaded to S3 with the help of <a
+        href="https://www.nextflow.io/">Nextflow</a
+    > and <a href="https://cloud.seqera.io/">Seqera Platform</a>. All of that was
+    made possible by <a href="https://registry.opendata.aws/"
+        >Open Data on AWS</a
+    >.
+    <br />
+    <a href="https://registry.opendata.aws/"
+        ><img
+            title="Open Data on AWS"
+            src="/AWS_logo.png"
+            height="100"
+        /></a
+    >
+    <a href="https://nf-co.re/"
+        ><img title="nf-core" src="/nf-core_logo.png" height="100" /></a
+    >
+</p>


### PR DESCRIPTION
Footer.astro was wrapping its content in `<Layout title="Footer">`, creating a nested HTML document (`<html>`/`<head>`/`<body>`) inside the parent page's slot.

This is invisible in rendered output but produces invalid nested HTML.