### PR TITLE
chore: rename package from @example/basics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@example/basics",
+    "name": "annotation-cache.github.io",
     "type": "module",
     "version": "0.0.1",
     "private": true,


### PR DESCRIPTION
Drop the starter template name in favor of the actual project name.