### PR TITLE
chore: simplify package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
             },
             "devDependencies": {
                 "@astrojs/check": "^0.9.9",
-                "markdownlint-cli2": "^0.17.0",
-                "prettier": "^3.6.2",
                 "typescript": "^6.0.3"
             }
         },
@@ -1294,44 +1292,6 @@
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "license": "MIT"
         },
-        "node_modules/@nodelib/fs.scandir": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "2.0.5",
-                "run-parallel": "^1.1.9"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.stat": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/@nodelib/fs.walk": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.scandir": "2.1.5",
-                "fastq": "^1.6.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/@oslojs/encoding": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
@@ -1824,19 +1784,6 @@
             "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
             "license": "MIT"
         },
-        "node_modules/@sindresorhus/merge-streams": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-            "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@types/debug": {
             "version": "4.1.13",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1860,13 +1807,6 @@
             "dependencies": {
                 "@types/unist": "*"
             }
-        },
-        "node_modules/@types/katex": {
-            "version": "0.16.8",
-            "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
-            "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/mdast": {
             "version": "4.0.4",
@@ -2210,19 +2150,6 @@
             "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
             "license": "ISC"
         },
-        "node_modules/braces": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/ccount": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -2257,17 +2184,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
             "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/character-reference-invalid": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
-            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -2811,23 +2727,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/fast-glob": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
         "node_modules/fast-string-truncated-width": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -2869,16 +2768,6 @@
                 "fast-string-width": "^3.0.2"
             }
         },
-        "node_modules/fastq": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "reusify": "^1.0.4"
-            }
-        },
         "node_modules/fdir": {
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2894,19 +2783,6 @@
                 "picomatch": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/fill-range": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/flattie": {
@@ -2982,50 +2858,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
             "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
-        },
-        "node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/globby": {
-            "version": "14.0.2",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-14.0.2.tgz",
-            "integrity": "sha512-s3Fq41ZVh7vbbe2PN3nrW7yC7U7MFVc5c98/iTl9c2GawNMKx/J648KQRW6WKkuU8GIbbh2IXfIRQjOZnXcTnw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sindresorhus/merge-streams": "^2.1.0",
-                "fast-glob": "^3.3.2",
-                "ignore": "^5.2.4",
-                "path-type": "^5.0.0",
-                "slash": "^5.1.0",
-                "unicorn-magic": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby/node_modules/ignore": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
         },
         "node_modules/h3": {
             "version": "1.15.11",
@@ -3251,43 +3083,6 @@
                 "url": "https://github.com/sponsors/brc-dd"
             }
         },
-        "node_modules/is-alphabetical": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/is-alphanumerical": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
-            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-alphabetical": "^2.0.0",
-                "is-decimal": "^2.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/is-decimal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/is-docker": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
@@ -3303,16 +3098,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-extglob": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3321,30 +3106,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-glob": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extglob": "^2.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-hexadecimal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
-            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-inside-container": {
@@ -3378,16 +3139,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
             }
         },
         "node_modules/is-plain-obj": {
@@ -3442,33 +3193,6 @@
             "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
             "license": "MIT"
         },
-        "node_modules/katex": {
-            "version": "0.16.47",
-            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-            "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-            "dev": true,
-            "funding": [
-                "https://opencollective.com/katex",
-                "https://github.com/sponsors/katex"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "commander": "^8.3.0"
-            },
-            "bin": {
-                "katex": "cli.js"
-            }
-        },
-        "node_modules/katex/node_modules/commander": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
         "node_modules/kleur": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -3477,26 +3201,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/linkify-it": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/markdown-it"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "uc.micro": "^2.0.0"
             }
         },
         "node_modules/longest-streak": {
@@ -3547,237 +3251,6 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
-        },
-        "node_modules/markdownlint-cli2": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.17.2.tgz",
-            "integrity": "sha512-XH06ZOi8wCrtOSSj3p8y3yJzwgzYOSa7lglNyS3fP05JPRzRGyjauBb5UvlLUSCGysMmULS1moxdRHHudV+g/Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "globby": "14.0.2",
-                "js-yaml": "4.1.0",
-                "jsonc-parser": "3.3.1",
-                "markdownlint": "0.37.4",
-                "markdownlint-cli2-formatter-default": "0.0.5",
-                "micromatch": "4.0.8"
-            },
-            "bin": {
-                "markdownlint-cli2": "markdownlint-cli2-bin.mjs"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/DavidAnson"
-            }
-        },
-        "node_modules/markdownlint-cli2-formatter-default": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.5.tgz",
-            "integrity": "sha512-4XKTwQ5m1+Txo2kuQ3Jgpo/KmnG+X90dWt4acufg6HVGadTUG5hzHF/wssp9b5MBYOMCnZ9RMPaU//uHsszF8Q==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/DavidAnson"
-            },
-            "peerDependencies": {
-                "markdownlint-cli2": ">=0.0.4"
-            }
-        },
-        "node_modules/markdownlint-cli2/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/markdownlint-cli2/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
-        "node_modules/markdownlint-cli2/node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
-                "mdurl": "^2.0.0",
-                "punycode.js": "^2.3.1",
-                "uc.micro": "^2.1.0"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.mjs"
-            }
-        },
-        "node_modules/markdownlint-cli2/node_modules/markdownlint": {
-            "version": "0.37.4",
-            "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.37.4.tgz",
-            "integrity": "sha512-u00joA/syf3VhWh6/ybVFkib5Zpj2e5KB/cfCei8fkSRuums6nyisTWGqjTWIOFoFwuXoTBQQiqlB4qFKp8ncQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "markdown-it": "14.1.0",
-                "micromark": "4.0.1",
-                "micromark-core-commonmark": "2.0.2",
-                "micromark-extension-directive": "3.0.2",
-                "micromark-extension-gfm-autolink-literal": "2.1.0",
-                "micromark-extension-gfm-footnote": "2.1.0",
-                "micromark-extension-gfm-table": "2.1.0",
-                "micromark-extension-math": "3.1.0",
-                "micromark-util-types": "2.0.1"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/DavidAnson"
-            }
-        },
-        "node_modules/markdownlint-cli2/node_modules/micromark": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.1.tgz",
-            "integrity": "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@types/debug": "^4.0.0",
-                "debug": "^4.0.0",
-                "decode-named-character-reference": "^1.0.0",
-                "devlop": "^1.0.0",
-                "micromark-core-commonmark": "^2.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-chunked": "^2.0.0",
-                "micromark-util-combine-extensions": "^2.0.0",
-                "micromark-util-decode-numeric-character-reference": "^2.0.0",
-                "micromark-util-encode": "^2.0.0",
-                "micromark-util-normalize-identifier": "^2.0.0",
-                "micromark-util-resolve-all": "^2.0.0",
-                "micromark-util-sanitize-uri": "^2.0.0",
-                "micromark-util-subtokenize": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/markdownlint-cli2/node_modules/micromark-core-commonmark": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz",
-            "integrity": "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "decode-named-character-reference": "^1.0.0",
-                "devlop": "^1.0.0",
-                "micromark-factory-destination": "^2.0.0",
-                "micromark-factory-label": "^2.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-factory-title": "^2.0.0",
-                "micromark-factory-whitespace": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-chunked": "^2.0.0",
-                "micromark-util-classify-character": "^2.0.0",
-                "micromark-util-html-tag-name": "^2.0.0",
-                "micromark-util-normalize-identifier": "^2.0.0",
-                "micromark-util-resolve-all": "^2.0.0",
-                "micromark-util-subtokenize": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/markdownlint-cli2/node_modules/micromark-extension-directive": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-3.0.2.tgz",
-            "integrity": "sha512-wjcXHgk+PPdmvR58Le9d7zQYWy+vKEU9Se44p2CrCDPiLr2FMyiT4Fyb5UFKFC66wGB3kPlgD7q3TnoqPS7SZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "devlop": "^1.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-factory-whitespace": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0",
-                "parse-entities": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/markdownlint-cli2/node_modules/micromark-extension-gfm-table": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz",
-            "integrity": "sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "devlop": "^1.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/markdownlint-cli2/node_modules/micromark-util-types": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
-            "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/mdast-util-definitions": {
             "version": "6.0.0",
@@ -4010,23 +3483,6 @@
             "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
             "license": "CC0-1.0"
         },
-        "node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/micromark": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -4207,26 +3663,6 @@
             "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-math": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
-            "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/katex": "^0.16.0",
-                "devlop": "^1.0.0",
-                "katex": "^0.16.0",
                 "micromark-factory-space": "^2.0.0",
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0",
@@ -4610,33 +4046,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/mrmime": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -4825,33 +4234,6 @@
             "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
             "license": "MIT"
         },
-        "node_modules/parse-entities": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
-            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "character-entities-legacy": "^3.0.0",
-                "character-reference-invalid": "^2.0.0",
-                "decode-named-character-reference": "^1.0.0",
-                "is-alphanumerical": "^2.0.0",
-                "is-decimal": "^2.0.0",
-                "is-hexadecimal": "^2.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/parse-entities/node_modules/@types/unist": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/parse-latin": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -4888,19 +4270,6 @@
             "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/path-type": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
-            "integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/piccolore": {
             "version": "0.1.3",
@@ -4988,37 +4357,6 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
-        },
-        "node_modules/punycode.js": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/queue-microtask": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/radix3": {
             "version": "1.1.2",
@@ -5302,17 +4640,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/reusify": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/rollup": {
             "version": "4.60.4",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
@@ -5362,30 +4689,6 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "license": "MIT"
-        },
-        "node_modules/run-parallel": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "queue-microtask": "^1.2.2"
-            }
         },
         "node_modules/sax": {
             "version": "1.6.0",
@@ -5477,19 +4780,6 @@
             "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
             "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
             "license": "MIT"
-        },
-        "node_modules/slash": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-            "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/smol-toml": {
             "version": "1.6.1",
@@ -5601,19 +4891,6 @@
                 "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-number": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
         "node_modules/trim-lines": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -5672,13 +4949,6 @@
                 "semver": "^7.3.8"
             }
         },
-        "node_modules/uc.micro": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/ufo": {
             "version": "1.6.4",
             "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
@@ -5696,19 +4966,6 @@
             "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
             "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
             "license": "MIT"
-        },
-        "node_modules/unicorn-magic": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
-            "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
         },
         "node_modules/unified": {
             "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -5,23 +5,17 @@
     "private": true,
     "scripts": {
         "dev": "astro dev",
-        "start": "astro dev",
         "build": "astro build",
         "preview": "astro preview",
         "check": "astro check",
-        "format": "prettier --check .",
-        "format:fix": "prettier --write .",
-        "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules' '!dist'",
-        "lint": "npm run check && npm run lint:md",
-        "astro": "astro"
+        "lint": "npm run check",
+        "prek": "prek run"
     },
     "dependencies": {
         "astro": "^6.4.2"
     },
     "devDependencies": {
         "@astrojs/check": "^0.9.9",
-        "markdownlint-cli2": "^0.17.0",
-        "prettier": "^3.6.2",
         "typescript": "^6.0.3"
     }
 }


### PR DESCRIPTION
Remove redundant scripts (start, format, format:fix, lint:md, astro) and unused devDependencies (prettier, markdownlint-cli2). prek handles formatting and linting instead.