### PR TITLE
feat: dark theme with three-way toggle, improve tool pages and footer

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -9,12 +9,35 @@ const pathname = Astro.url.pathname;
             <span>Annotation Cache</span>
         </a>
         <input type="checkbox" id="menu-toggle" class="menu-toggle" />
-        <label for="menu-toggle" class="menu-icon" aria-label="Toggle menu">&#9776;</label>
         <ul class="nav-links">
             <li><a href="/ensemblvep/" aria-current={pathname.startsWith("/ensemblvep") ? "page" : undefined}>Ensembl VEP</a></li>
             <li><a href="/snpeff/" aria-current={pathname.startsWith("/snpeff") ? "page" : undefined}>SnpEff</a></li>
             <li><a href="/svanna/" aria-current={pathname.startsWith("/svanna") ? "page" : undefined}>SvAnna</a></li>
             <li><a href="/about/" aria-current={pathname.startsWith("/about") ? "page" : undefined}>About</a></li>
         </ul>
+        <div class="nav-end">
+            <label for="menu-toggle" class="menu-icon" aria-label="Toggle menu">&#9776;</label>
+            <div class="theme-dropdown">
+                <button
+                    id="theme-toggle"
+                    type="button"
+                    title="Select theme"
+                    aria-label="Select theme"
+                >
+                    <i class="fa-solid fa-moon" aria-hidden="true"></i>
+                </button>
+                <div class="theme-dropdown-menu">
+                    <button class="theme-option" data-theme="light">
+                        <i class="fa-solid fa-sun"></i> Light
+                    </button>
+                    <button class="theme-option" data-theme="dark">
+                        <i class="fa-solid fa-moon"></i> Dark
+                    </button>
+                    <button class="theme-option" data-theme="auto">
+                        <i class="fa-solid fa-adjust"></i> System
+                    </button>
+                </div>
+            </div>
+        </div>
     </div>
 </nav>

--- a/src/layouts/Footer.astro
+++ b/src/layouts/Footer.astro
@@ -1,5 +1,5 @@
 <p class="footer">
-    Annotation-cache is based on <a
+    <a href="https://github.com/annotation-cache"><i class="fa-brands fa-github"></i> Annotation-cache</a> is based on <a
         href="https://www.ensembl.org/info/docs/tools/vep/index.html"
         >Ensembl VEP</a
     >, <a href="https://pcingola.github.io/SnpEff/">SnpEff</a> and <a

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,6 +25,21 @@ const { title } = Astro.props;
         />
         <meta name="generator" content={Astro.generator} />
         <title>{title}</title>
+        <script is:inline>
+            (function () {
+                var saved = localStorage.getItem("theme");
+                var theme = "light";
+                if (saved === "dark" || saved === "light") {
+                    theme = saved;
+                } else if (
+                    !saved &&
+                    window.matchMedia("(prefers-color-scheme: dark)").matches
+                ) {
+                    theme = "dark";
+                }
+                document.documentElement.setAttribute("data-theme", theme);
+            })();
+        </script>
     </head>
     <body>
         <main>
@@ -33,3 +48,82 @@ const { title } = Astro.props;
         </main>
     </body>
 </html>
+
+<script>
+    function resolveTheme(saved: string | null): string {
+        if (saved === "dark") return "dark";
+        if (saved === "light") return "light";
+        return window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+    }
+
+    function setTheme(saved: string | null): void {
+        const theme = resolveTheme(saved);
+        document.documentElement.setAttribute("data-theme", theme);
+        updateToggleIcon(theme);
+        setActiveOption(saved);
+    }
+
+    function updateToggleIcon(theme: string): void {
+        const icon = document.querySelector("#theme-toggle i");
+        if (!icon) return;
+        icon.className = "fa-solid";
+        icon.classList.add(
+            theme === "dark" ? "fa-moon" : "fa-sun",
+        );
+    }
+
+    function setActiveOption(saved: string | null): void {
+        document.querySelectorAll(".theme-option").forEach((opt) => {
+            const el = opt as HTMLElement;
+            el.classList.toggle(
+                "active",
+                el.dataset.theme === saved,
+            );
+        });
+    }
+
+    function switchTheme(e: Event): void {
+        const opt = e.currentTarget as HTMLElement | null;
+        if (!opt?.dataset?.theme) return;
+        const saved = opt.dataset.theme;
+        localStorage.setItem("theme", saved);
+        setTheme(saved);
+        closeDropdown();
+    }
+
+    function toggleDropdown(e: Event): void {
+        e.stopPropagation();
+        const dropdown = document.querySelector(".theme-dropdown");
+        dropdown?.classList.toggle("open");
+    }
+
+    function closeDropdown(): void {
+        document.querySelector(".theme-dropdown")?.classList.remove("open");
+    }
+
+    const saved = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
+    setTheme(saved || (prefersDark.matches ? "dark" : "light"));
+    if (!saved) localStorage.setItem("theme", "auto");
+    setActiveOption(saved || "auto");
+
+    document
+        .getElementById("theme-toggle")
+        ?.addEventListener("click", toggleDropdown);
+
+    document.querySelectorAll(".theme-option").forEach((opt) => {
+        opt.addEventListener("click", switchTheme);
+    });
+
+    document.addEventListener("click", (e: Event) => {
+        const target = e.target as HTMLElement | null;
+        if (target && !target.closest(".theme-dropdown")) closeDropdown();
+    });
+
+    prefersDark.addEventListener("change", () => {
+        const current = localStorage.getItem("theme");
+        if (!current || current === "auto") setTheme("auto");
+    });
+</script>

--- a/src/pages/ensemblvep.md
+++ b/src/pages/ensemblvep.md
@@ -3,6 +3,8 @@ title: Ensembl VEP Cache
 layout: ../layouts/Page.astro
 ---
 
+[Ensembl VEP](https://www.ensembl.org/info/docs/tools/vep/index.html) (Variant Effect Predictor) determines the functional effects of genomic variants on gene transcripts, proteins, and regulatory regions. It supports a wide range of variant types and genome assemblies, providing comprehensive annotations including consequence predictions, population frequencies, and pathogenicity scores.
+
 The cache is organized by Ensembl VEP cache version / genome build.
 Running this command with `--no-sign-request` will allow you to see the contents of the bucket:
 

--- a/src/pages/snpeff.md
+++ b/src/pages/snpeff.md
@@ -3,6 +3,8 @@ title: SnpEff Cache
 layout: ../layouts/Page.astro
 ---
 
+[SnpEff](https://pcingola.github.io/SnpEff/) is a variant annotation and effect prediction tool that annotates and predicts the effects of genetic variants (such as SNPs, insertions, deletions, and MNPs) on genes and proteins. It categorizes variants by their impact (high, moderate, low, modifier) and provides detailed functional annotations.
+
 The cache is organized by genome build / SnpEff cache version.
 Running this command with `--no-sign-request` will allow you to see the contents of the bucket:
 

--- a/src/pages/svanna.md
+++ b/src/pages/svanna.md
@@ -3,7 +3,9 @@ title: SvAnna DB
 layout: ../layouts/Page.astro
 ---
 
-SvAnna (Structural Variant Annotation and Analysis) assesses all classes of structural variants and their intersection with transcripts and regulatory sequences, relating predicted effects on gene function with clinical phenotype data.
+[SvAnna](https://github.com/monarch-initiative/SvAnna) (Structural Variant Annotation and Analysis) assesses all classes of structural variants and their intersection with transcripts and regulatory sequences, relating predicted effects on gene function with clinical phenotype data.
+
+The cache is organized by SvAnna DB version.
 
 Use this command with `--no-sign-request` to see the available versions:
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,16 +2,56 @@
     --accent: 13, 192, 159;
     --accent-light: 182, 236, 226;
     --accent-dark: 5, 76, 63;
+    --heading-color: rgb(var(--accent-dark));
     --accent-gradient: linear-gradient(
         45deg,
         rgb(var(--accent)),
         rgb(var(--accent-dark)) 30%,
         white 60%
     );
+    --bg: #ffffff;
+    --text: #333333;
+    --card-bg: #ffffff;
+    --card-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    --card-shadow-hover: 0 8px 24px rgba(0, 0, 0, 0.12);
+    --description-color: #666;
+    --code-bg: #f5f5f5;
+    --code-border: #e0e0e0;
+    --code-output-bg: #fafafa;
+    --code-output-color: #555;
+    --sync-bg: #f0f8f4;
+    --sync-border: #c8e6c9;
+    --sync-color: #2e7d32;
 }
+
+html[data-theme="dark"] {
+    --heading-color: rgb(var(--accent-light));
+    --accent-gradient: linear-gradient(
+        45deg,
+        rgb(var(--accent)),
+        rgb(var(--accent-light)) 30%,
+        rgb(var(--accent-dark)) 60%
+    );
+    --bg: #1a1a1a;
+    --text: #e0e0e0;
+    --card-bg: #2d2d2d;
+    --card-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    --card-shadow-hover: 0 8px 24px rgba(0, 0, 0, 0.5);
+    --description-color: #aaa;
+    --code-bg: #2a2a2a;
+    --code-border: #444;
+    --code-output-bg: #222;
+    --code-output-color: #bbb;
+    --sync-bg: #1a3a1a;
+    --sync-border: #2e7d32;
+    --sync-color: #81c784;
+}
+
 html {
     font-family: system-ui, sans-serif;
-    background: #ffffff;
+    background: var(--bg);
+    color: var(--text);
+    transition: background 0.3s, color 0.3s;
 }
 code {
     font-family:
@@ -42,7 +82,7 @@ h1 {
 h2 {
     margin: 0;
     font-size: 1.35rem;
-    color: rgb(var(--accent-dark));
+    color: var(--heading-color);
 }
 .text-gradient {
     background-image: var(--accent-gradient);
@@ -66,7 +106,6 @@ nav {
 .nav-inner {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     padding: 1rem;
     background: linear-gradient(135deg, rgb(var(--accent-dark)), rgb(var(--accent)));
     border-radius: 8px;
@@ -87,7 +126,7 @@ nav {
     display: flex;
     gap: 1.5rem;
     list-style: none;
-    margin: 0;
+    margin: 0 1rem 0 auto;
     padding: 0;
 }
 .nav-links a {
@@ -113,6 +152,66 @@ nav {
     color: white;
     cursor: pointer;
     user-select: none;
+}
+#theme-toggle {
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 6px;
+    color: white;
+    cursor: pointer;
+    font-size: 0.95rem;
+    padding: 0.35rem 0.6rem;
+    transition: border-color 0.2s;
+}
+#theme-toggle:hover {
+    border-color: white;
+}
+.nav-end {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.theme-dropdown {
+    position: relative;
+}
+.theme-dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 0.5rem;
+    background: rgb(var(--accent-dark));
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    padding: 0.5rem 0;
+    min-width: 140px;
+    z-index: 200;
+}
+.theme-dropdown.open .theme-dropdown-menu {
+    display: flex;
+    flex-direction: column;
+}
+.theme-option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.85);
+    cursor: pointer;
+    font-size: 0.9rem;
+    padding: 0.5rem 1rem;
+    text-align: left;
+    width: 100%;
+    transition: background 0.2s, color 0.2s;
+}
+.theme-option:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+}
+.theme-option.active {
+    color: white;
+    font-weight: 600;
 }
 @media (max-width: 640px) {
     .menu-icon {
@@ -144,6 +243,9 @@ nav {
     .nav-inner {
         position: relative;
     }
+    .nav-end {
+        margin-left: auto;
+    }
 }
 
 /* Card */
@@ -157,10 +259,10 @@ nav {
     list-style: none;
     display: flex;
     position: relative;
-    background: white;
+    background: var(--card-bg);
     border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    transition: transform 0.2s, box-shadow 0.2s;
+    box-shadow: var(--card-shadow);
+    transition: transform 0.2s, box-shadow 0.2s, background 0.3s;
     overflow: hidden;
 }
 .link-card::before {
@@ -183,8 +285,9 @@ nav {
 .description {
     margin: 0;
     font-size: 0.95rem;
-    color: #666;
+    color: var(--description-color);
     line-height: 1.5;
+    transition: color 0.3s;
 }
 .button {
     display: inline-flex;
@@ -203,7 +306,7 @@ nav {
 }
 .link-card:hover {
     transform: translateY(-4px);
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+    box-shadow: var(--card-shadow-hover);
 }
 .link-card:hover::before {
     width: 6px;
@@ -214,12 +317,13 @@ nav {
 
 /* Page card */
 .page-card {
-    background: white;
+    background: var(--card-bg);
     border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    box-shadow: var(--card-shadow);
     padding: 1.5rem 2rem;
     position: relative;
     overflow: hidden;
+    transition: background 0.3s, box-shadow 0.3s;
 }
 .page-card::before {
     content: "";
@@ -232,7 +336,7 @@ nav {
 }
 .page-card h2 {
     margin: 0 0 1rem;
-    color: rgb(var(--accent-dark));
+    color: var(--heading-color);
 }
 .page-card p {
     margin: 0;
@@ -255,6 +359,7 @@ nav {
     border-radius: 8px;
     color: white;
     font-size: 0.95rem;
+    transition: border-color 0.3s;
 }
 .footer a {
     color: rgb(var(--accent-light));


### PR DESCRIPTION
## Changes

- **Dark theme**: CSS custom properties for both themes, three-way dropdown toggle (Light/Dark/System) with localStorage persistence and system preference listener
- **Navbar**: Theme toggle dropdown on the right, burger menu moved beside it, nav links right-aligned
- **Footer**: Added GitHub org link with icon
- **Tool pages**: Added project descriptions and links for SnpEff, Ensembl VEP, and SvAnna, plus cache organization note for SvAnna
- **Flash prevention**: Inline blocking script in <head> prevents light theme flash for dark mode users
