### PR TITLE
feat: add VEP cache 116_GRCh38 to listing

### DIFF
--- a/src/pages/ensemblvep.md
+++ b/src/pages/ensemblvep.md
@@ -31,16 +31,17 @@ aws s3 ls s3://annotation-cache/vep_cache/
     PRE 115_GRCh37/
     PRE 115_GRCh38/
     PRE 115_WBcel235/
+    PRE 116_GRCh38/
 ```
 
 You can then use such a command to sync any genome of interest locally
 
 ```bash
-aws s3 --no-sign-request --region eu-west-1 sync s3://annotation-cache/vep_cache/115_GRCh38/ ./vep_cache/
+aws s3 --no-sign-request --region eu-west-1 sync s3://annotation-cache/vep_cache/116_GRCh38/ ./vep_cache/
 ```
 
 Or alternatively this command if you are in a cloud setup with multiple genome versions:
 
 ```bash
-aws s3 --no-sign-request --region eu-west-1 sync s3://annotation-cache/vep_cache/115_GRCh38/ ./vep_cache/115_GRCh38/
+aws s3 --no-sign-request --region eu-west-1 sync s3://annotation-cache/vep_cache/116_GRCh38/ ./vep_cache/116_GRCh38/
 ```


### PR DESCRIPTION
Add VEP cache version 116 for GRCh38 to the annotation cache website.

Changes:
- Added `PRE 116_GRCh38/` to the cache listing
- Updated example sync commands to use version 116

Based on `main` branch (rebased from previous PR #31 which was based on wrong branch).