### PR TITLE
fix: ignore TypeScript major version updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@ updates:
       npm:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This PR adds an ignore rule for TypeScript major version updates in Dependabot to prevent PRs that are incompatible with @astrojs/check@0.9.9 (which only supports TypeScript ^5.0.0 || ^6.0.0).